### PR TITLE
Generate and deploy rdoc on GH pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,25 @@
+name: Github Pages (rdoc)
+on: [push]
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@master
+
+      - name: Set up Ruby 💎
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: '3.1'
+
+      - name: Install rdoc and generate docs 🔧
+        run: |
+          gem install rdoc
+          rdoc --op rdocs
+
+      - name: Deploy 🚀
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./rdocs


### PR DESCRIPTION
# Why
There are documentation written inline with the code in syntax_tree. As Kevin suggested, it'd be great if we could have to have an rdoc site. 

# Changes
Using the GH Action - [`peaceiris/actions-gh-pages` ](https://github.com/peaceiris/actions-gh-pages), generate docs using rdoc in `./rdocs` and deploy it to GH pages

# Test
This workflow seems to be working on [my fork's project page](https://mapleong.me/syntax_tree/)
