### PR TITLE
Exclude vendor and other directories when generating rdoc

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install rdoc and generate docs 🔧
         run: |
           gem install rdoc
-          rdoc --op rdocs
+          rdoc --op rdocs --exclude={Gemfile,Rakefile,"vendor/*","bin/*","test/*"}
 
       - name: Deploy 🚀
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Exclude: 
- Gemfile
- Rakefile
- "vendor/*"
- "bin/*"
- "test/*"

We initially only talked about the vendor directory. However, I made the decision to add the rest of the directories because they didn't contain any documentation (and so was formatted poorly) and cluttered up the side bar.  

[Tested on my fork](https://mapleong.me/syntax_tree/)