### PR TITLE
Ignore the vendor/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/
 
 test.rb


### PR DESCRIPTION
QoL

And it seems we're already expecting to ignore it [here](https://github.com/ruby-syntax-tree/syntax_tree/blob/main/.github/workflows/gh-pages.yml#L19).