### PR TITLE
Implement visitor pattern for SyntaxTree::Node

### DIFF
--- a/lib/syntax_tree/visitor.rb
+++ b/lib/syntax_tree/visitor.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SyntaxTree
+  class Visitor
+    def visit_all(nodes)
+      nodes.each do |node|
+        visit(node)
+      end
+    end
+
+    def visit(node)
+      node&.accept(self)
+    end
+  end
+end

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "objspace"
+
+class VisitorTest < Minitest::Test
+  def test_can_visit_all_nodes
+    visitor = SyntaxTree::Visitor.new
+
+    ObjectSpace.each_object(SyntaxTree::Node.singleton_class)
+      .reject { |node| node.singleton_class? || node == SyntaxTree::Node }
+      .each { |node| assert_respond_to(visitor, node.visit_method_name) }
+  end
+
+  def test_node_visit_method_name
+    assert_equal("visit_t_string_end", SyntaxTree::TStringEnd.visit_method_name)
+  end
+
+  def test_visit_tree
+    parsed_tree = SyntaxTree.parse(<<~RUBY)
+      class Foo
+        def foo; end
+
+        class Bar
+          def bar; end
+        end
+      end
+
+      def baz; end
+    RUBY
+
+    visitor = DummyVisitor.new
+    visitor.visit(parsed_tree)
+    assert_equal(["Foo", "foo", "Bar", "bar", "baz"], visitor.visited_nodes)
+  end
+
+  class DummyVisitor < SyntaxTree::Visitor
+    attr_reader :visited_nodes
+
+    def initialize
+      super
+      @visited_nodes = []
+    end
+
+    def visit_class_declaration(node)
+      @visited_nodes << node.constant.constant.value
+      super
+    end
+
+    def visit_def(node)
+      @visited_nodes << node.name.value
+    end
+  end
+end


### PR DESCRIPTION
# What, why?

This pattern will expand our horizons and allow us to do fun stuff with the nodes through the `SyntaxTree::Visitor` class. Right now we are using metaprogramming to create and `#send` to call our `#visit_` methods the LSP. Ideally this would be a built in feature in `syntax_tree` so others can use it as well. 

We've chosen to require the `Visitor` class in `node.rb` to make it clearer that the file requires it. Otherwise, we'd have to add it to `lib/syntax_tree.rb` in an order-dependent way, which we decided was less desirable.

# Who
Co-authored-by: Kaan Ozkan <kaan.ozkan@shopify.com>
Co-authored-by: Alexandre Terrasa <alexandre.terrasa@shopify.com>
Co-authored-by: Vinicius Stock <vinicius.stock@shopify.com>
Co-authored-by: Emily Giurleo <emily.giurleo@shopify.com>
Co-authored-by: Rafael Franca <rafael.franca@shopify.com>