### PR TITLE
Visitors

### DIFF
--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -1871,7 +1871,6 @@ module SyntaxTree
     end
   end
 
-
   # Binary represents any expression that involves two sub-expressions with an
   # operator in between. This can be something that looks like a mathematical
   # operation:

--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -58,27 +58,8 @@ module SyntaxTree
     # [Location] the location of this node
     attr_reader :location
 
-    def self.inherited(child)
-      child.class_eval(<<~EOS, __FILE__, __LINE__ + 1)
-        def accept(visitor)
-          visitor.#{child.visit_method_name}(self)
-        end
-      EOS
-
-      Visitor.class_eval(<<~EOS, __FILE__, __LINE__ + 1)
-        def #{child.visit_method_name}(node)
-          visit_all(node.child_nodes)
-        end
-      EOS
-    end
-
-    def self.visit_method_name
-      method_suffix = name.split("::").last
-      method_suffix.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
-      method_suffix.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
-      method_suffix.tr!("-", "_")
-      method_suffix.downcase!
-      "visit_#{method_suffix}"
+    def accept(visitor)
+      raise NotImplementedError
     end
 
     def child_nodes
@@ -130,6 +111,10 @@ module SyntaxTree
       @statements = statements
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_BEGIN(self)
     end
 
     def child_nodes
@@ -201,6 +186,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_CHAR(self)
+    end
+
     def child_nodes
       []
     end
@@ -263,6 +252,10 @@ module SyntaxTree
       @statements = statements
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_END(self)
     end
 
     def child_nodes
@@ -335,6 +328,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit___end__(self)
     end
 
     def child_nodes
@@ -426,6 +423,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_alias(self)
+    end
+
     def child_nodes
       [left, right]
     end
@@ -507,6 +508,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_aref(self)
+    end
+
     def child_nodes
       [collection, index]
     end
@@ -586,6 +591,10 @@ module SyntaxTree
       @index = index
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_aref_field(self)
     end
 
     def child_nodes
@@ -670,6 +679,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_arg_paren(self)
+    end
+
     def child_nodes
       [arguments]
     end
@@ -734,6 +747,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_args(self)
+    end
+
     def child_nodes
       parts
     end
@@ -781,6 +798,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_arg_block(self)
     end
 
     def child_nodes
@@ -833,6 +854,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_arg_star(self)
     end
 
     def child_nodes
@@ -896,6 +921,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_args_forward(self)
     end
 
     def child_nodes
@@ -1025,6 +1054,10 @@ module SyntaxTree
       @contents = contents
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_array(self)
     end
 
     def child_nodes
@@ -1199,6 +1232,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_aryptn(self)
+    end
+
     def child_nodes
       [constant, *requireds, rest, *posts]
     end
@@ -1326,6 +1363,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_assign(self)
+    end
+
     def child_nodes
       [target, value]
     end
@@ -1408,6 +1449,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_assoc(self)
+    end
+
     def child_nodes
       [key, value]
     end
@@ -1488,6 +1533,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_assoc_splat(self)
+    end
+
     def child_nodes
       [value]
     end
@@ -1542,6 +1591,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_backref(self)
+    end
+
     def child_nodes
       []
     end
@@ -1588,6 +1641,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_backtick(self)
     end
 
     def child_nodes
@@ -1704,6 +1761,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_bare_assoc_hash(self)
+    end
+
     def child_nodes
       assocs
     end
@@ -1760,6 +1821,10 @@ module SyntaxTree
       @bodystmt = bodystmt
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_begin(self)
     end
 
     def child_nodes
@@ -1824,6 +1889,10 @@ module SyntaxTree
       @statement = statement
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_pinned_begin(self)
     end
 
     def child_nodes
@@ -1900,6 +1969,10 @@ module SyntaxTree
       @right = right
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_binary(self)
     end
 
     def child_nodes
@@ -2035,6 +2108,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_block_var(self)
+    end
+
     def child_nodes
       [params, *locals]
     end
@@ -2099,6 +2176,10 @@ module SyntaxTree
       @name = name
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_block_arg(self)
     end
 
     def child_nodes
@@ -2200,6 +2281,10 @@ module SyntaxTree
 
     def empty?
       statements.empty? && !rescue_clause && !else_clause && !ensure_clause
+    end
+
+    def accept(visitor)
+      visitor.visit_bodystmt(self)
     end
 
     def child_nodes
@@ -2471,6 +2556,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_brace_block(self)
+    end
+
     def child_nodes
       [lbrace, block_var, statements]
     end
@@ -2591,6 +2680,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_break(self)
+    end
+
     def child_nodes
       [arguments]
     end
@@ -2680,6 +2773,10 @@ module SyntaxTree
       @arguments = arguments
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_call(self)
     end
 
     def child_nodes
@@ -2799,6 +2896,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_case(self)
+    end
+
     def child_nodes
       [keyword, value, consequent]
     end
@@ -2887,6 +2988,10 @@ module SyntaxTree
       @pattern = pattern
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_rassign(self)
     end
 
     def child_nodes
@@ -3002,6 +3107,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_class(self)
+    end
+
     def child_nodes
       [constant, superclass, bodystmt]
     end
@@ -3088,6 +3197,10 @@ module SyntaxTree
     # [String] the comma in the string
     attr_reader :value
 
+    def accept(visitor)
+      visitor.visit_comma(self)
+    end
+
     def initialize(value:, location:)
       @value = value
       @location = location
@@ -3115,6 +3228,10 @@ module SyntaxTree
       @arguments = arguments
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_command(self)
     end
 
     def child_nodes
@@ -3200,6 +3317,10 @@ module SyntaxTree
       @arguments = arguments
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_command_call(self)
     end
 
     def child_nodes
@@ -3381,6 +3502,10 @@ module SyntaxTree
       []
     end
 
+    def accept(visitor)
+      visitor.visit_comment(self)
+    end
+
     def child_nodes
       []
     end
@@ -3441,6 +3566,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_const(self)
+    end
+
     def child_nodes
       []
     end
@@ -3494,6 +3623,10 @@ module SyntaxTree
       @constant = constant
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_const_path_field(self)
     end
 
     def child_nodes
@@ -3563,6 +3696,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_const_path_ref(self)
+    end
+
     def child_nodes
       [parent, constant]
     end
@@ -3628,6 +3765,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_const_ref(self)
+    end
+
     def child_nodes
       [constant]
     end
@@ -3678,6 +3819,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_cvar(self)
     end
 
     def child_nodes
@@ -3735,6 +3880,10 @@ module SyntaxTree
       @bodystmt = bodystmt
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_def(self)
     end
 
     def child_nodes
@@ -3843,6 +3992,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_def_endless(self)
+    end
+
     def child_nodes
       [target, operator, name, paren, statement]
     end
@@ -3945,6 +4098,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_defined(self)
+    end
+
     def child_nodes
       [value]
     end
@@ -4022,6 +4179,10 @@ module SyntaxTree
       @bodystmt = bodystmt
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_defs(self)
     end
 
     def child_nodes
@@ -4128,6 +4289,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_do_block(self)
+    end
+
     def child_nodes
       [keyword, block_var, bodystmt]
     end
@@ -4231,6 +4396,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_dot2(self)
+    end
+
     def child_nodes
       [left, right]
     end
@@ -4301,6 +4470,10 @@ module SyntaxTree
       @right = right
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_dot3(self)
     end
 
     def child_nodes
@@ -4414,6 +4587,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_dyna_symbol(self)
+    end
+
     def child_nodes
       parts
     end
@@ -4522,6 +4699,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_else(self)
+    end
+
     def child_nodes
       [statements]
     end
@@ -4594,6 +4775,10 @@ module SyntaxTree
       @consequent = consequent
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_elsif(self)
     end
 
     def child_nodes
@@ -4694,6 +4879,10 @@ module SyntaxTree
       []
     end
 
+    def accept(visitor)
+      visitor.visit_embdoc(self)
+    end
+
     def child_nodes
       []
     end
@@ -4733,6 +4922,10 @@ module SyntaxTree
     # [String] the #{ used in the string
     attr_reader :value
 
+    def accept(visitor)
+      visitor.visit_embexpr_beg(self)
+    end
+
     def initialize(value:, location:)
       @value = value
       @location = location
@@ -4748,6 +4941,10 @@ module SyntaxTree
   class EmbExprEnd < Node
     # [String] the } used in the string
     attr_reader :value
+
+    def accept(visitor)
+      visitor.visit_embexpr_end(self)
+    end
 
     def initialize(value:, location:)
       @value = value
@@ -4766,6 +4963,10 @@ module SyntaxTree
   class EmbVar < Node
     # [String] the # used in the string
     attr_reader :value
+
+    def accept(visitor)
+      visitor.visit_embvar(self)
+    end
 
     def initialize(value:, location:)
       @value = value
@@ -4795,6 +4996,10 @@ module SyntaxTree
       @statements = statements
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_ensure(self)
     end
 
     def child_nodes
@@ -4868,6 +5073,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_excessed_comma(self)
+    end
+
     def child_nodes
       []
     end
@@ -4925,6 +5134,10 @@ module SyntaxTree
       @arguments = arguments
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_fcall(self)
     end
 
     def child_nodes
@@ -5000,6 +5213,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_field(self)
+    end
+
     def child_nodes
       [parent, (operator if operator != :"::"), name]
     end
@@ -5070,6 +5287,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_float(self)
+    end
+
     def child_nodes
       []
     end
@@ -5133,6 +5354,10 @@ module SyntaxTree
       @right = right
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_fndptn(self)
     end
 
     def child_nodes
@@ -5229,6 +5454,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_for(self)
+    end
+
     def child_nodes
       [index, collection, statements]
     end
@@ -5310,6 +5539,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_gvar(self)
+    end
+
     def child_nodes
       []
     end
@@ -5361,6 +5594,10 @@ module SyntaxTree
       @assocs = assocs
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_hash(self)
     end
 
     def child_nodes
@@ -5451,6 +5688,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_heredoc(self)
+    end
+
     def child_nodes
       [beginning, *parts]
     end
@@ -5539,6 +5780,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_heredoc_beg(self)
     end
 
     def child_nodes
@@ -5649,6 +5894,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_hshptn(self)
+    end
+
     def child_nodes
       [constant, *keywords.flatten(1), keyword_rest]
     end
@@ -5754,6 +6003,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_ident(self)
     end
 
     def child_nodes
@@ -5901,6 +6154,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_if(self)
+    end
+
     def child_nodes
       [predicate, statements, consequent]
     end
@@ -5975,6 +6232,10 @@ module SyntaxTree
       @falsy = falsy
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_if_op(self)
     end
 
     def child_nodes
@@ -6139,6 +6400,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_if_mod(self)
+    end
+
     def child_nodes
       [statement, predicate]
     end
@@ -6200,6 +6465,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_imaginary(self)
+    end
+
     def child_nodes
       []
     end
@@ -6258,6 +6527,10 @@ module SyntaxTree
       @consequent = consequent
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_in(self)
     end
 
     def child_nodes
@@ -6345,6 +6618,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_int(self)
+    end
+
     def child_nodes
       []
     end
@@ -6398,6 +6675,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_ivar(self)
     end
 
     def child_nodes
@@ -6458,6 +6739,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_kw(self)
+    end
+
     def child_nodes
       []
     end
@@ -6504,6 +6789,10 @@ module SyntaxTree
       @name = name
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_kwrest_param(self)
     end
 
     def child_nodes
@@ -6568,6 +6857,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_label(self)
+    end
+
     def child_nodes
       []
     end
@@ -6612,6 +6905,10 @@ module SyntaxTree
     # [String] the end of the label
     attr_reader :value
 
+    def accept(visitor)
+      visitor.visit_label_end(self)
+    end
+
     def initialize(value:, location:)
       @value = value
       @location = location
@@ -6637,6 +6934,10 @@ module SyntaxTree
       @statements = statements
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_lambda(self)
     end
 
     def child_nodes
@@ -6728,6 +7029,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_lbrace(self)
+    end
+
     def child_nodes
       []
     end
@@ -6774,6 +7079,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_lbracket(self)
+    end
+
     def child_nodes
       []
     end
@@ -6818,6 +7127,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_lparen(self)
     end
 
     def child_nodes
@@ -6881,6 +7194,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_massign(self)
     end
 
     def child_nodes
@@ -6950,6 +7267,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_method_add_block(self)
+    end
+
     def child_nodes
       [call, block]
     end
@@ -7015,6 +7336,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_mlhs(self)
+    end
+
     def child_nodes
       parts
     end
@@ -7068,6 +7393,10 @@ module SyntaxTree
       @contents = contents
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_mlhs_paren(self)
     end
 
     def child_nodes
@@ -7138,6 +7467,10 @@ module SyntaxTree
       @bodystmt = bodystmt
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_module(self)
     end
 
     def child_nodes
@@ -7227,6 +7560,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_mrhs(self)
+    end
+
     def child_nodes
       parts
     end
@@ -7289,6 +7626,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_next(self)
+    end
+
     def child_nodes
       [arguments]
     end
@@ -7337,6 +7678,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_op(self)
     end
 
     def child_nodes
@@ -7394,6 +7739,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_op_assign(self)
     end
 
     def child_nodes
@@ -7646,6 +7995,10 @@ module SyntaxTree
         keywords.empty? && !keyword_rest && !block
     end
 
+    def accept(visitor)
+      visitor.visit_params(self)
+    end
+
     def child_nodes
       [
         *requireds,
@@ -7811,6 +8164,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_paren(self)
+    end
+
     def child_nodes
       [lparen, contents]
     end
@@ -7879,6 +8236,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_period(self)
+    end
+
     def child_nodes
       []
     end
@@ -7923,6 +8284,10 @@ module SyntaxTree
       @statements = statements
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_program(self)
     end
 
     def child_nodes
@@ -7985,6 +8350,10 @@ module SyntaxTree
       @elements = elements
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_qsymbols(self)
     end
 
     def child_nodes
@@ -8053,6 +8422,10 @@ module SyntaxTree
     # [String] the beginning of the array literal
     attr_reader :value
 
+    def accept(visitor)
+      visitor.visit_qsymbols_beg(self)
+    end
+
     def initialize(value:, location:)
       @value = value
       @location = location
@@ -8078,6 +8451,10 @@ module SyntaxTree
       @elements = elements
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_qwords(self)
     end
 
     def child_nodes
@@ -8143,6 +8520,10 @@ module SyntaxTree
     # [String] the beginning of the array literal
     attr_reader :value
 
+    def accept(visitor)
+      visitor.visit_qwords_beg(self)
+    end
+
     def initialize(value:, location:)
       @value = value
       @location = location
@@ -8164,6 +8545,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_rational(self)
     end
 
     def child_nodes
@@ -8203,6 +8588,10 @@ module SyntaxTree
     # [String] the right brace
     attr_reader :value
 
+    def accept(visitor)
+      visitor.visit_rbrace(self)
+    end
+
     def initialize(value:, location:)
       @value = value
       @location = location
@@ -8213,6 +8602,10 @@ module SyntaxTree
   class RBracket < Node
     # [String] the right bracket
     attr_reader :value
+
+    def accept(visitor)
+      visitor.visit_rbracket(self)
+    end
 
     def initialize(value:, location:)
       @value = value
@@ -8235,6 +8628,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_redo(self)
     end
 
     def child_nodes
@@ -8283,6 +8680,10 @@ module SyntaxTree
     # regular expression
     attr_reader :parts
 
+    def accept(visitor)
+      visitor.visit_regexp_content(self)
+    end
+
     def initialize(beginning:, parts:, location:)
       @beginning = beginning
       @parts = parts
@@ -8303,6 +8704,10 @@ module SyntaxTree
     # [String] the beginning of the regular expression
     attr_reader :value
 
+    def accept(visitor)
+      visitor.visit_regexp_beg(self)
+    end
+
     def initialize(value:, location:)
       @value = value
       @location = location
@@ -8322,6 +8727,10 @@ module SyntaxTree
   class RegexpEnd < Node
     # [String] the end of the regular expression
     attr_reader :value
+
+    def accept(visitor)
+      visitor.visit_regexp_end(self)
+    end
 
     def initialize(value:, location:)
       @value = value
@@ -8353,6 +8762,10 @@ module SyntaxTree
       @parts = parts
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_regexp_literal(self)
     end
 
     def child_nodes
@@ -8478,6 +8891,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_rescue_ex(self)
+    end
+
     def child_nodes
       [*exceptions, variable]
     end
@@ -8582,6 +8999,10 @@ module SyntaxTree
       end
     end
 
+    def accept(visitor)
+      visitor.visit_rescue(self)
+    end
+
     def child_nodes
       [exception, statements, consequent]
     end
@@ -8676,6 +9097,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_rescue_mod(self)
+    end
+
     def child_nodes
       [statement, value]
     end
@@ -8750,6 +9175,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_rest_param(self)
+    end
+
     def child_nodes
       [name]
     end
@@ -8798,6 +9227,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_retry(self)
     end
 
     def child_nodes
@@ -8849,6 +9282,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_return(self)
+    end
+
     def child_nodes
       [arguments]
     end
@@ -8898,6 +9335,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_return0(self)
+    end
+
     def child_nodes
       []
     end
@@ -8935,6 +9376,10 @@ module SyntaxTree
     # [String] the parenthesis
     attr_reader :value
 
+    def accept(visitor)
+      visitor.visit_rparen(self)
+    end
+
     def initialize(value:, location:)
       @value = value
       @location = location
@@ -8963,6 +9408,10 @@ module SyntaxTree
       @bodystmt = bodystmt
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_sclass(self)
     end
 
     def child_nodes
@@ -9079,6 +9528,10 @@ module SyntaxTree
       body.all? do |statement|
         statement.is_a?(VoidStmt) && statement.comments.empty?
       end
+    end
+
+    def accept(visitor)
+      visitor.visit_statements(self)
     end
 
     def child_nodes
@@ -9203,6 +9656,10 @@ module SyntaxTree
     # string
     attr_reader :parts
 
+    def accept(visitor)
+      visitor.visit_string_content(self)
+    end
+
     def initialize(parts:, location:)
       @parts = parts
       @location = location
@@ -9230,6 +9687,10 @@ module SyntaxTree
       @right = right
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_string_concat(self)
     end
 
     def child_nodes
@@ -9297,6 +9758,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_string_dvar(self)
+    end
+
     def child_nodes
       [variable]
     end
@@ -9351,6 +9816,10 @@ module SyntaxTree
       @statements = statements
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_string_embexpr(self)
     end
 
     def child_nodes
@@ -9425,6 +9894,10 @@ module SyntaxTree
       @quote = quote
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_string_literal(self)
     end
 
     def child_nodes
@@ -9507,6 +9980,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_super(self)
+    end
+
     def child_nodes
       [arguments]
     end
@@ -9568,6 +10045,10 @@ module SyntaxTree
     # [String] the beginning of the symbol
     attr_reader :value
 
+    def accept(visitor)
+      visitor.visit_sym_beg(self)
+    end
+
     def initialize(value:, location:)
       @value = value
       @location = location
@@ -9583,6 +10064,10 @@ module SyntaxTree
     # [Backtick | Const | CVar | GVar | Ident | IVar | Kw | Op] the value of the
     # symbol
     attr_reader :value
+
+    def accept(visitor)
+      visitor.visit_symbol_content(self)
+    end
 
     def initialize(value:, location:)
       @value = value
@@ -9607,6 +10092,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_symbol_literal(self)
     end
 
     def child_nodes
@@ -9664,6 +10153,10 @@ module SyntaxTree
       @elements = elements
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_symbols(self)
     end
 
     def child_nodes
@@ -9733,6 +10226,10 @@ module SyntaxTree
     # [String] the beginning of the symbol literal array
     attr_reader :value
 
+    def accept(visitor)
+      visitor.visit_symbols_beg(self)
+    end
+
     def initialize(value:, location:)
       @value = value
       @location = location
@@ -9747,6 +10244,10 @@ module SyntaxTree
   class TLambda < Node
     # [String] the beginning of the lambda literal
     attr_reader :value
+
+    def accept(visitor)
+      visitor.visit_tlambda(self)
+    end
 
     def initialize(value:, location:)
       @value = value
@@ -9763,6 +10264,10 @@ module SyntaxTree
   class TLamBeg < Node
     # [String] the beginning of the body of the lambda literal
     attr_reader :value
+
+    def accept(visitor)
+      visitor.visit_tlambeg(self)
+    end
 
     def initialize(value:, location:)
       @value = value
@@ -9787,6 +10292,10 @@ module SyntaxTree
       @constant = constant
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_top_const_field(self)
     end
 
     def child_nodes
@@ -9843,6 +10352,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_top_const_ref(self)
+    end
+
     def child_nodes
       [constant]
     end
@@ -9893,6 +10406,10 @@ module SyntaxTree
     # [String] the beginning of the string
     attr_reader :value
 
+    def accept(visitor)
+      visitor.visit_tstring_beg(self)
+    end
+
     def initialize(value:, location:)
       @value = value
       @location = location
@@ -9922,6 +10439,10 @@ module SyntaxTree
 
     def match?(pattern)
       value.match?(pattern)
+    end
+
+    def accept(visitor)
+      visitor.visit_tstring_content(self)
     end
 
     def child_nodes
@@ -9973,6 +10494,10 @@ module SyntaxTree
     # [String] the end of the string
     attr_reader :value
 
+    def accept(visitor)
+      visitor.visit_tstring_end(self)
+    end
+
     def initialize(value:, location:)
       @value = value
       @location = location
@@ -9998,6 +10523,10 @@ module SyntaxTree
       @parentheses = parentheses
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_not(self)
     end
 
     def child_nodes
@@ -10063,6 +10592,10 @@ module SyntaxTree
       @statement = statement
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_unary(self)
     end
 
     def child_nodes
@@ -10148,6 +10681,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_undef(self)
+    end
+
     def child_nodes
       symbols
     end
@@ -10220,6 +10757,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_unless(self)
+    end
+
     def child_nodes
       [predicate, statements, consequent]
     end
@@ -10290,6 +10831,10 @@ module SyntaxTree
       @predicate = predicate
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_unless_mod(self)
     end
 
     def child_nodes
@@ -10407,6 +10952,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_until(self)
+    end
+
     def child_nodes
       [predicate, statements]
     end
@@ -10481,6 +11030,10 @@ module SyntaxTree
       @predicate = predicate
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_until_mod(self)
     end
 
     def child_nodes
@@ -10569,6 +11122,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_var_alias(self)
+    end
+
     def child_nodes
       [left, right]
     end
@@ -10632,6 +11189,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_var_field(self)
+    end
+
     def child_nodes
       [value]
     end
@@ -10683,6 +11244,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_var_ref(self)
     end
 
     def child_nodes
@@ -10737,6 +11302,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_pinned_var_ref(self)
     end
 
     def child_nodes
@@ -10795,6 +11364,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_vcall(self)
+    end
+
     def child_nodes
       [value]
     end
@@ -10841,6 +11414,10 @@ module SyntaxTree
     def initialize(location:, comments: [])
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_void_stmt(self)
     end
 
     def child_nodes
@@ -10899,6 +11476,10 @@ module SyntaxTree
       @consequent = consequent
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_when(self)
     end
 
     def child_nodes
@@ -11008,6 +11589,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_while(self)
+    end
+
     def child_nodes
       [predicate, statements]
     end
@@ -11082,6 +11667,10 @@ module SyntaxTree
       @predicate = predicate
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_while_mod(self)
     end
 
     def child_nodes
@@ -11173,6 +11762,10 @@ module SyntaxTree
       parts.any? { |part| part.is_a?(TStringContent) && part.match?(pattern) }
     end
 
+    def accept(visitor)
+      visitor.visit_word(self)
+    end
+
     def child_nodes
       parts
     end
@@ -11224,6 +11817,10 @@ module SyntaxTree
       @elements = elements
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_words(self)
     end
 
     def child_nodes
@@ -11290,6 +11887,10 @@ module SyntaxTree
     # [String] the start of the word literal array
     attr_reader :value
 
+    def accept(visitor)
+      visitor.visit_words_beg(self)
+    end
+
     def initialize(value:, location:)
       @value = value
       @location = location
@@ -11304,6 +11905,10 @@ module SyntaxTree
     # [Array[ StringEmbExpr | StringDVar | TStringContent ]] the parts of the
     # xstring
     attr_reader :parts
+
+    def accept(visitor)
+      visitor.visit_xstring(self)
+    end
 
     def initialize(parts:, location:)
       @parts = parts
@@ -11327,6 +11932,10 @@ module SyntaxTree
       @parts = parts
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_xstring_literal(self)
     end
 
     def child_nodes
@@ -11381,6 +11990,10 @@ module SyntaxTree
       @arguments = arguments
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_yield(self)
     end
 
     def child_nodes
@@ -11446,6 +12059,10 @@ module SyntaxTree
       @comments = comments
     end
 
+    def accept(visitor)
+      visitor.visit_yield0(self)
+    end
+
     def child_nodes
       []
     end
@@ -11493,6 +12110,10 @@ module SyntaxTree
       @value = value
       @location = location
       @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_zsuper(self)
     end
 
     def child_nodes

--- a/lib/syntax_tree/visitor.rb
+++ b/lib/syntax_tree/visitor.rb
@@ -2,14 +2,542 @@
 
 module SyntaxTree
   class Visitor
-    def visit_all(nodes)
-      nodes.each do |node|
-        visit(node)
+    # This is raised when you use the Visitor.visit_method method and it fails.
+    # It is correctable to through DidYouMean.
+    class VisitMethodError < StandardError
+      attr_reader :visit_method
+
+      def initialize(visit_method)
+        @visit_method = visit_method
+        super("Invalid visit method: #{visit_method}")
+      end
+    end
+
+    # This class is used by DidYouMean to offer corrections to invalid visit
+    # method names.
+    class VisitMethodChecker
+      attr_reader :visit_method
+
+      def initialize(error)
+        @visit_method = error.visit_method
+      end
+
+      def corrections
+        @corrections ||=
+          DidYouMean::SpellChecker.new(dictionary: Visitor.visit_methods).correct(visit_method)
+      end
+
+      DidYouMean.correct_error(VisitMethodError, self)
+    end
+
+    class << self
+      # This method is here to help folks write visitors.
+      #
+      # It's not always easy to ensure you're writing the correct method name in
+      # the visitor since it's perfectly valid to define methods that don't
+      # override these parent methods.
+      #
+      # If you use this method, you can ensure you're writing the correct method
+      # name. It will raise an error if the visit method you're defining isn't
+      # actually a method on the parent visitor.
+      def visit_method(method_name)
+        return if visit_methods.include?(method_name)
+
+        raise VisitMethodError, method_name
+      end
+
+      # This is the list of all of the valid visit methods.
+      def visit_methods
+        Visitor.instance_methods.grep(/^visit_(?!child_nodes)/)
       end
     end
 
     def visit(node)
-      node&.accept(self)
+      node.accept(self)
     end
+
+    def visit_child_nodes(node)
+      node.child_nodes.each { |child_node| visit(child_node) if child_node }
+    end
+
+    # Visit an ARef node.
+    alias visit_aref visit_child_nodes
+
+    # Visit an ARefField node.
+    alias visit_aref_field visit_child_nodes
+
+    # Visit an Alias node.
+    alias visit_alias visit_child_nodes
+
+    # Visit an ArgBlock node.
+    alias visit_arg_block visit_child_nodes
+
+    # Visit an ArgParen node.
+    alias visit_arg_paren visit_child_nodes
+
+    # Visit an ArgStar node.
+    alias visit_arg_star visit_child_nodes
+
+    # Visit an Args node.
+    alias visit_args visit_child_nodes
+
+    # Visit an ArgsForward node.
+    alias visit_args_forward visit_child_nodes
+
+    # Visit an ArrayLiteral node.
+    alias visit_array visit_child_nodes
+
+    # Visit an AryPtn node.
+    alias visit_aryptn visit_child_nodes
+
+    # Visit an Assign node.
+    alias visit_assign visit_child_nodes
+
+    # Visit an Assoc node.
+    alias visit_assoc visit_child_nodes
+
+    # Visit an AssocSplat node.
+    alias visit_assoc_splat visit_child_nodes
+
+    # Visit a BEGINBlock node.
+    alias visit_BEGIN visit_child_nodes
+
+    # Visit a Backref node.
+    alias visit_backref visit_child_nodes
+
+    # Visit a Backtick node.
+    alias visit_backtick visit_child_nodes
+
+    # Visit a BareAssocHash node.
+    alias visit_bare_assoc_hash visit_child_nodes
+
+    # Visit a Begin node.
+    alias visit_begin visit_child_nodes
+
+    # Visit a Binary node.
+    alias visit_binary visit_child_nodes
+
+    # Visit a BlockArg node.
+    alias visit_block_arg visit_child_nodes
+
+    # Visit a BlockVar node.
+    alias visit_block_var visit_child_nodes
+
+    # Visit a BodyStmt node.
+    alias visit_bodystmt visit_child_nodes
+
+    # Visit a BraceBlock node.
+    alias visit_brace_block visit_child_nodes
+
+    # Visit a Break node.
+    alias visit_break visit_child_nodes
+
+    # Visit a CHAR node.
+    alias visit_CHAR visit_child_nodes
+
+    # Visit a CVar node.
+    alias visit_cvar visit_child_nodes
+
+    # Visit a Call node.
+    alias visit_call visit_child_nodes
+
+    # Visit a Case node.
+    alias visit_case visit_child_nodes
+
+    # Visit a ClassDeclaration node.
+    alias visit_class visit_child_nodes
+
+    # Visit a Comma node.
+    alias visit_comma visit_child_nodes
+
+    # Visit a Command node.
+    alias visit_command visit_child_nodes
+
+    # Visit a CommandCall node.
+    alias visit_command_call visit_child_nodes
+
+    # Visit a Comment node.
+    alias visit_comment visit_child_nodes
+
+    # Visit a Const node.
+    alias visit_const visit_child_nodes
+
+    # Visit a ConstPathField node.
+    alias visit_const_path_field visit_child_nodes
+
+    # Visit a ConstPathRef node.
+    alias visit_const_path_ref visit_child_nodes
+
+    # Visit a ConstRef node.
+    alias visit_const_ref visit_child_nodes
+
+    # Visit a Def node.
+    alias visit_def visit_child_nodes
+
+    # Visit a DefEndless node.
+    alias visit_def_endless visit_child_nodes
+
+    # Visit a Defined node.
+    alias visit_defined visit_child_nodes
+
+    # Visit a Defs node.
+    alias visit_defs visit_child_nodes
+
+    # Visit a DoBlock node.
+    alias visit_do_block visit_child_nodes
+
+    # Visit a Dot2 node.
+    alias visit_dot2 visit_child_nodes
+
+    # Visit a Dot3 node.
+    alias visit_dot3 visit_child_nodes
+
+    # Visit a DynaSymbol node.
+    alias visit_dyna_symbol visit_child_nodes
+
+    # Visit an ENDBlock node.
+    alias visit_END visit_child_nodes
+
+    # Visit an Else node.
+    alias visit_else visit_child_nodes
+
+    # Visit an Elsif node.
+    alias visit_elsif visit_child_nodes
+
+    # Visit an EmbDoc node.
+    alias visit_embdoc visit_child_nodes
+
+    # Visit an EmbExprBeg node.
+    alias visit_embexpr_beg visit_child_nodes
+
+    # Visit an EmbExprEnd node.
+    alias visit_embexpr_end visit_child_nodes
+
+    # Visit an EmbVar node.
+    alias visit_embvar visit_child_nodes
+
+    # Visit an EndContent node.
+    alias visit___end__ visit_child_nodes
+
+    # Visit an Ensure node.
+    alias visit_ensure visit_child_nodes
+
+    # Visit an ExcessedComma node.
+    alias visit_excessed_comma visit_child_nodes
+
+    # Visit a FCall node.
+    alias visit_fcall visit_child_nodes
+
+    # Visit a Field node.
+    alias visit_field visit_child_nodes
+
+    # Visit a FloatLiteral node.
+    alias visit_float visit_child_nodes
+
+    # Visit a FndPtn node.
+    alias visit_fndptn visit_child_nodes
+
+    # Visit a For node.
+    alias visit_for visit_child_nodes
+
+    # Visit a GVar node.
+    alias visit_gvar visit_child_nodes
+
+    # Visit a HashLiteral node.
+    alias visit_hash visit_child_nodes
+
+    # Visit a Heredoc node.
+    alias visit_heredoc visit_child_nodes
+
+    # Visit a HeredocBeg node.
+    alias visit_heredoc_beg visit_child_nodes
+
+    # Visit a HshPtn node.
+    alias visit_hshptn visit_child_nodes
+
+    # Visit an IVar node.
+    alias visit_ivar visit_child_nodes
+
+    # Visit an Ident node.
+    alias visit_ident visit_child_nodes
+
+    # Visit an If node.
+    alias visit_if visit_child_nodes
+
+    # Visit an IfMod node.
+    alias visit_if_mod visit_child_nodes
+
+    # Visit an IfOp node.
+    alias visit_if_op visit_child_nodes
+
+    # Visit an Imaginary node.
+    alias visit_imaginary visit_child_nodes
+
+    # Visit an In node.
+    alias visit_in visit_child_nodes
+
+    # Visit an Int node.
+    alias visit_int visit_child_nodes
+
+    # Visit a Kw node.
+    alias visit_kw visit_child_nodes
+
+    # Visit a KwRestParam node.
+    alias visit_kwrest_param visit_child_nodes
+
+    # Visit a LBrace node.
+    alias visit_lbrace visit_child_nodes
+
+    # Visit a LBracket node.
+    alias visit_lbracket visit_child_nodes
+
+    # Visit a LParen node.
+    alias visit_lparen visit_child_nodes
+
+    # Visit a Label node.
+    alias visit_label visit_child_nodes
+
+    # Visit a LabelEnd node.
+    alias visit_label_end visit_child_nodes
+
+    # Visit a Lambda node.
+    alias visit_lambda visit_child_nodes
+
+    # Visit a MAssign node.
+    alias visit_massign visit_child_nodes
+
+    # Visit a MLHS node.
+    alias visit_mlhs visit_child_nodes
+
+    # Visit a MLHSParen node.
+    alias visit_mlhs_paren visit_child_nodes
+
+    # Visit a MRHS node.
+    alias visit_mrhs visit_child_nodes
+
+    # Visit a MethodAddBlock node.
+    alias visit_method_add_block visit_child_nodes
+
+    # Visit a ModuleDeclaration node.
+    alias visit_module visit_child_nodes
+
+    # Visit a Next node.
+    alias visit_next visit_child_nodes
+
+    # Visit a Not node.
+    alias visit_not visit_child_nodes
+
+    # Visit an Op node.
+    alias visit_op visit_child_nodes
+
+    # Visit an OpAssign node.
+    alias visit_op_assign visit_child_nodes
+
+    # Visit a Params node.
+    alias visit_params visit_child_nodes
+
+    # Visit a Paren node.
+    alias visit_paren visit_child_nodes
+
+    # Visit a Period node.
+    alias visit_period visit_child_nodes
+
+    # Visit a PinnedBegin node.
+    alias visit_pinned_begin visit_child_nodes
+
+    # Visit a PinnedVarRef node.
+    alias visit_pinned_var_ref visit_child_nodes
+
+    # Visit a Program node.
+    alias visit_program visit_child_nodes
+
+    # Visit a QSymbols node.
+    alias visit_qsymbols visit_child_nodes
+
+    # Visit a QSymbolsBeg node.
+    alias visit_qsymbols_beg visit_child_nodes
+
+    # Visit a QWords node.
+    alias visit_qwords visit_child_nodes
+
+    # Visit a QWordsBeg node.
+    alias visit_qwords_beg visit_child_nodes
+
+    # Visit a RAssign node.
+    alias visit_rassign visit_child_nodes
+
+    # Visit a RBrace node.
+    alias visit_rbrace visit_child_nodes
+
+    # Visit a RBracket node.
+    alias visit_rbracket visit_child_nodes
+
+    # Visit a RParen node.
+    alias visit_rparen visit_child_nodes
+
+    # Visit a RationalLiteral node.
+    alias visit_rational visit_child_nodes
+
+    # Visit a Redo node.
+    alias visit_redo visit_child_nodes
+
+    # Visit a RegexpBeg node.
+    alias visit_regexp_beg visit_child_nodes
+
+    # Visit a RegexpContent node.
+    alias visit_regexp_content visit_child_nodes
+
+    # Visit a RegexpEnd node.
+    alias visit_regexp_end visit_child_nodes
+
+    # Visit a RegexpLiteral node.
+    alias visit_regexp_literal visit_child_nodes
+
+    # Visit a Rescue node.
+    alias visit_rescue visit_child_nodes
+
+    # Visit a RescueEx node.
+    alias visit_rescue_ex visit_child_nodes
+
+    # Visit a RescueMod node.
+    alias visit_rescue_mod visit_child_nodes
+
+    # Visit a RestParam node.
+    alias visit_rest_param visit_child_nodes
+
+    # Visit a Retry node.
+    alias visit_retry visit_child_nodes
+
+    # Visit a Return node.
+    alias visit_return visit_child_nodes
+
+    # Visit a Return0 node.
+    alias visit_return0 visit_child_nodes
+
+    # Visit a SClass node.
+    alias visit_sclass visit_child_nodes
+
+    # Visit a Statements node.
+    alias visit_statements visit_child_nodes
+
+    # Visit a StringConcat node.
+    alias visit_string_concat visit_child_nodes
+
+    # Visit a StringContent node.
+    alias visit_string_content visit_child_nodes
+
+    # Visit a StringDVar node.
+    alias visit_string_dvar visit_child_nodes
+
+    # Visit a StringEmbExpr node.
+    alias visit_string_embexpr visit_child_nodes
+
+    # Visit a StringLiteral node.
+    alias visit_string_literal visit_child_nodes
+
+    # Visit a Super node.
+    alias visit_super visit_child_nodes
+
+    # Visit a SymBeg node.
+    alias visit_sym_beg visit_child_nodes
+
+    # Visit a SymbolContent node.
+    alias visit_symbol_content visit_child_nodes
+
+    # Visit a SymbolLiteral node.
+    alias visit_symbol_literal visit_child_nodes
+
+    # Visit a Symbols node.
+    alias visit_symbols visit_child_nodes
+
+    # Visit a SymbolsBeg node.
+    alias visit_symbols_beg visit_child_nodes
+
+    # Visit a TLamBeg node.
+    alias visit_tlambeg visit_child_nodes
+
+    # Visit a TLambda node.
+    alias visit_tlambda visit_child_nodes
+
+    # Visit a TStringBeg node.
+    alias visit_tstring_beg visit_child_nodes
+
+    # Visit a TStringContent node.
+    alias visit_tstring_content visit_child_nodes
+
+    # Visit a TStringEnd node.
+    alias visit_tstring_end visit_child_nodes
+
+    # Visit a TopConstField node.
+    alias visit_top_const_field visit_child_nodes
+
+    # Visit a TopConstRef node.
+    alias visit_top_const_ref visit_child_nodes
+
+    # Visit an Unary node.
+    alias visit_unary visit_child_nodes
+
+    # Visit an Undef node.
+    alias visit_undef visit_child_nodes
+
+    # Visit an Unless node.
+    alias visit_unless visit_child_nodes
+
+    # Visit an UnlessMod node.
+    alias visit_unless_mod visit_child_nodes
+
+    # Visit an Until node.
+    alias visit_until visit_child_nodes
+
+    # Visit an UntilMod node.
+    alias visit_until_mod visit_child_nodes
+
+    # Visit a VCall node.
+    alias visit_vcall visit_child_nodes
+
+    # Visit a VarAlias node.
+    alias visit_var_alias visit_child_nodes
+
+    # Visit a VarField node.
+    alias visit_var_field visit_child_nodes
+
+    # Visit a VarRef node.
+    alias visit_var_ref visit_child_nodes
+
+    # Visit a VoidStmt node.
+    alias visit_void_stmt visit_child_nodes
+
+    # Visit a When node.
+    alias visit_when visit_child_nodes
+
+    # Visit a While node.
+    alias visit_while visit_child_nodes
+
+    # Visit a WhileMod node.
+    alias visit_while_mod visit_child_nodes
+
+    # Visit a Word node.
+    alias visit_word visit_child_nodes
+
+    # Visit a Words node.
+    alias visit_words visit_child_nodes
+
+    # Visit a WordsBeg node.
+    alias visit_words_beg visit_child_nodes
+
+    # Visit a XString node.
+    alias visit_xstring visit_child_nodes
+
+    # Visit a XStringLiteral node.
+    alias visit_xstring_literal visit_child_nodes
+
+    # Visit a Yield node.
+    alias visit_yield visit_child_nodes
+
+    # Visit a Yield0 node.
+    alias visit_yield0 visit_child_nodes
+
+    # Visit a ZSuper node.
+    alias visit_zsuper visit_child_nodes
   end
 end


### PR DESCRIPTION
Piggy-backing on the great work by @wildmaples and team.

I want to keep the visitor pattern around because I think it's going to be very useful. However, I'm really not a fan of the `class_eval` approach. A couple of questions arise:

* How do you discover the name of the visit method for each of the nodes?
* Where does the documentation for the visit methods live?
* How fast is it to load the node.rb file?
* Is it clear what is happening within the regex?

I'd rather be very explicit about the names of the methods on the classes. Also, since their names (for the most part) come from ripper, I'd like to keep their visit methods as close to those as possible. For example, the ripper method for visiting string content is `def on_tstring_content`, the class name is `TStringContent`, but the visit method would be `def visit_t_string_content`. I think that would be pretty surprising/confusing for new contributors.

In this PR instead I've chosen to write out each one manually (don't worry, I generated it with syntax tree). I think this will be more maintainable and lead to better documentation. I've also provided a `Visitor.visit_method` method, which should hopefully make it easier to write visitors. You would use it like this:

```ruby
class MyVisitor < SyntaxTree::Visitor
  visit_method def visit_comment(node)
    # do whatever here
  end
end
```

That `visit_method` call will ensure that you're naming the method correctly. If you have a typo (like `visit_coment`), then it will error. As a bonus, this PR uses `DidYouMean` to give an ever better DX.

For posterity, I generated the code below with the following script:

```ruby
#!/usr/bin/env ruby
# frozen_string_literal: true

require "bundler/setup"
require "syntax_tree"

NAMES = {
  "BEGINBlock" => "BEGIN",
  "CHAR" => "CHAR",
  "ENDBlock" => "END",
  "EndContent" => "__end__",
  "ArrayLiteral" => "array",
  "ARef" => "aref",
  "ARefField" => "aref_field",
  "AryPtn" => "aryptn",
  "BodyStmt" => "bodystmt",
  "RAssign" => "rassign",
  "ClassDeclaration" => "class",
  "CVar" => "cvar",
  "EmbDoc" => "embdoc",
  "EmbExprBeg" => "embexpr_beg",
  "EmbExprEnd" => "embexpr_end",
  "EmbVar" => "embvar",
  "FCall" => "fcall",
  "FloatLiteral" => "float",
  "FndPtn" => "fndptn",
  "GVar" => "gvar",
  "HashLiteral" => "hash",
  "HshPtn" => "hshptn",
  "IVar" => "ivar",
  "KwRestParam" => "kwrest_param",
  "LBrace" => "lbrace",
  "LBracket" => "lbracket",
  "LParen" => "lparen",
  "MAssign" => "massign",
  "MLHS" => "mlhs",
  "MLHSParen" => "mlhs_paren",
  "ModuleDeclaration" => "module",
  "MRHS" => "mrhs",
  "QSymbols" => "qsymbols",
  "QSymbolsBeg" => "qsymbols_beg",
  "QWords" => "qwords",
  "QWordsBeg" => "qwords_beg",
  "RationalLiteral" => "rational",
  "RBrace" => "rbrace",
  "RBracket" => "rbracket",
  "RParen" => "rparen",
  "SClass" => "sclass",
  "StringDVar" => "string_dvar",
  "StringEmbExpr" => "string_embexpr",
  "TLambda" => "tlambda",
  "TLamBeg" => "tlambeg",
  "TStringBeg" => "tstring_beg",
  "TStringContent" => "tstring_content",
  "TStringEnd" => "tstring_end",
  "VCall" => "vcall",
  "XString" => "xstring",
  "XStringLiteral" => "xstring_literal",
  "ZSuper" => "zsuper"
}

NAMES.default_proc = -> (hash, key) do
  value = key.dup
  value.gsub!(/([A-Z\d]+)([A-Z][a-z])/, '\1_\2')
  value.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
  value.tr!("-", "_")
  value.downcase!
  hash[key] = value
end

filepath = File.expand_path("../lib/syntax_tree/node.rb", __dir__)
source = SyntaxTree.read(filepath)

ast = SyntaxTree.parse(source)
ast => SyntaxTree::Program[statements: { body: [*, SyntaxTree::ModuleDeclaration[bodystmt: { statements: { body: classes } }]] }]

classes.each do |node|
  next unless node in SyntaxTree::ClassDeclaration[superclass: { value: { value: "Node" } }]

  body = node.bodystmt.statements.body
  index = body.index { _1 in SyntaxTree::Def[name: { value: "child_nodes" }] }
  index ||= body.length - 1

  body.insert(index, SyntaxTree.parse(<<~RUBY).statements.body.first)
    def accept(visitor)
      visitor.visit_#{NAMES[node.constant.constant.value]}(self)
    end
  RUBY

  body[index].location.instance_variable_set(:@start_line, node.location.end_line)
end

NAMES.sort.to_h.each do |original, change|
  puts <<~RUBY
    # Visit a#{original.match?(/^[AEIOU]/) ? "n" : ""} #{original} node.
    alias visit_#{change} visit_child_nodes

  RUBY
end

formatter = SyntaxTree::Formatter.new(source, [])
ast.format(formatter)

formatter.flush
File.write(filepath, formatter.output.join)
```