### PR TITLE
Allow passing `nil` to `visit`

### DIFF
--- a/lib/syntax_tree/visitor.rb
+++ b/lib/syntax_tree/visitor.rb
@@ -54,11 +54,11 @@ module SyntaxTree
     end
 
     def visit(node)
-      node.accept(self)
+      node&.accept(self)
     end
 
     def visit_child_nodes(node)
-      node.child_nodes.each { |child_node| visit(child_node) if child_node }
+      node.child_nodes.each { |child_node| visit(child_node) }
     end
 
     # Visit an ARef node.


### PR DESCRIPTION
Since a lot of nodes can be nil in the tree, let's provide some relief to the user.