### PR TITLE
Method prefixes

### DIFF
--- a/test/fixtures/command.rb
+++ b/test/fixtures/command.rb
@@ -5,3 +5,27 @@ foo barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr, bazzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
 -
 foo barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr,
     bazzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+%
+meta1 def foo
+end
+%
+meta2 meta1 def foo
+end
+%
+meta3 meta2 meta1 def foo
+end
+%
+meta1 def self.foo
+end
+%
+meta2 meta1 def self.foo
+end
+%
+meta3 meta2 meta1 def self.foo
+end
+%
+meta1 def foo = 1
+%
+meta2 meta1 def foo = 1
+%
+meta3 meta2 meta1 def foo = 1


### PR DESCRIPTION
We shouldn't indent Command nodes if they end in Def/Defs/DefEndless nodes.

Fixes #21