### PR TITLE
Fix documented type for BareAssocHash#assocs

### DIFF
--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -1749,7 +1749,7 @@ module SyntaxTree
   #     method(key1: value1, key2: value2)
   #
   class BareAssocHash < Node
-    # [Array[ AssocNew | AssocSplat ]]
+    # [Array[ Assoc | AssocSplat ]]
     attr_reader :assocs
 
     # [Array[ Comment | EmbDoc ]] the comments attached to this node


### PR DESCRIPTION
I didn't find any node class for `AssocNew` but I found one for [`Assoc`](https://github.com/ruby-syntax-tree/syntax_tree/blob/main/lib/syntax_tree/node.rb#L1435).