### PR TITLE
Block ampersand association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Changed
+
+- [#45](https://github.com/ruby-syntax-tree/syntax_tree/issues/45) - Fix parsing expressions like `foo.instance_exec(&T.must(block))`, where there are two `args_add_block` calls with a single `&`. Previously it was associating the `&` with the wrong block.
+
 ## [2.1.0] - 2022-04-12
 
 ### Added

--- a/test/fixtures/arg_block.rb
+++ b/test/fixtures/arg_block.rb
@@ -18,3 +18,5 @@ foo(
 def foo(&)
   bar(&)
 end
+% # https://github.com/ruby-syntax-tree/syntax_tree/issues/45
+foo.instance_exec(&T.must(block))


### PR DESCRIPTION
Fix parsing expressions like `foo.instance_exec(&T.must(block))`, where there are two `args_add_block` calls with a single `&`. Previously it was associating the `&` with the wrong block.

Fixes #45