### PR TITLE
Add convenient Formatter.format

### DIFF
--- a/lib/syntax_tree/formatter.rb
+++ b/lib/syntax_tree/formatter.rb
@@ -17,6 +17,13 @@ module SyntaxTree
       @quote = "\""
     end
 
+    def self.format(source, node)
+      formatter = new(source, [])
+      node.format(formatter)
+      formatter.flush
+      formatter.output.join
+    end
+
     def format(node, stackable: true)
       stack << node if stackable
       doc = nil

--- a/test/formatting_test.rb
+++ b/test/formatting_test.rb
@@ -9,5 +9,10 @@ module SyntaxTree
         assert_equal(fixture.formatted, SyntaxTree.format(fixture.source))
       end
     end
+
+    def test_format_class_level
+      source = "1+1"
+      assert_equal("1 + 1\n", SyntaxTree::Formatter.format(source, SyntaxTree.parse(source)))
+    end
   end
 end


### PR DESCRIPTION
Add a class level format method that accepts the source and the node we want to format.