### PR TITLE
Make missing kwargs `nil` instead of `false`

### DIFF
--- a/lib/syntax_tree/parser.rb
+++ b/lib/syntax_tree/parser.rb
@@ -2079,12 +2079,16 @@ module SyntaxTree
       keyword_rest,
       block
     )
+      # This is to make it so that required keyword arguments
+      # have a `nil` for the value instead of a `false`.
+      keywords&.map! { |(key, value)| [key, value || nil] }
+
       parts = [
         *requireds,
         *optionals&.flatten(1),
         rest,
         *posts,
-        *keywords&.flat_map { |(key, value)| [key, value || nil] },
+        *keywords&.flatten(1),
         (keyword_rest if keyword_rest != :nil),
         (block if block != :&)
       ].compact


### PR DESCRIPTION
If one of the keyword arguments is false, the `Visitor` class fails to visit `Params` [here](https://github.com/ruby-syntax-tree/syntax_tree/blob/37ae88050241cc8d3397d3c9e2ae8d30c4a96c1e/lib/syntax_tree/visitor.rb#L57) because `node` is `false` instead of `nil`.