### PR TITLE
Adding Features

### DIFF
--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -4680,6 +4680,11 @@ module SyntaxTree
         return
       end
 
+      if contains_conditional?
+        format_break(q, force: true)
+        return
+      end
+
       if node.consequent || node.statements.empty?
         q.group { format_break(q, force: true) }
       else
@@ -4715,6 +4720,11 @@ module SyntaxTree
 
       q.breakable(force: force)
       q.text("end")
+    end
+
+    def contains_conditional?
+      node.statements.body.length == 1 &&
+      [If, IfMod, IfOp, Unless, UnlessMod].include?(node.statements.body.first.class)
     end
   end
 

--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -2066,7 +2066,12 @@ module SyntaxTree
             part = arguments.parts.first
 
             if part.is_a?(Paren)
-              q.format(arguments)
+              if part.contents.body.length == 1 && skip_parens?(part.contents.body.first)
+                q.text(" ")
+                q.format(part.contents.body.first)
+              else
+                q.format(arguments)
+              end
             elsif part.is_a?(ArrayLiteral)
               q.text(" ")
               q.format(arguments)
@@ -2090,6 +2095,17 @@ module SyntaxTree
       end
       q.breakable("")
       q.if_break { q.text(closing) }
+    end
+
+    def skip_parens?(node)
+      case node
+      in Int | FloatLiteral
+        true
+      in VarRef[value: GVar | IVar | CVar | Kw | Const]
+        true
+      else
+        false
+      end
     end
   end
 

--- a/test/fixtures/if.rb
+++ b/test/fixtures/if.rb
@@ -28,3 +28,7 @@ end
 if (foo += 1)
   foo
 end
+%
+if foo
+  a ? b : c
+end

--- a/test/fixtures/next.rb
+++ b/test/fixtures/next.rb
@@ -25,3 +25,31 @@ next(
   foo
   bar
 )
+%
+next(1)
+-
+next 1
+%
+next(1.0)
+-
+next 1.0
+%
+next($a)
+-
+next $a
+%
+next(@@a)
+-
+next @@a
+%
+next(self)
+-
+next self
+%
+next(@a)
+-
+next @a
+%
+next(A)
+-
+next A

--- a/test/fixtures/unless.rb
+++ b/test/fixtures/unless.rb
@@ -28,3 +28,7 @@ end
 unless (foo += 1)
   foo
 end
+%
+unless foo
+  a ? b : c
+end


### PR DESCRIPTION
This PR is the result of our pairing session. To recap, we added:

- Allowing flow control operators to skip parens when they have single args (i.e. `next(1)` -> `next 1`)
- Prevented conditionals with a single line conditional statement as it's only statement from creating a single line conditional (i.e. Dont turn:
```ruby
if foo
  a ? b : c
end
```
into
```ruby
a ? b : c if foo
```

Please let me know if I missed anything. Thanks again for hanging out. it was a blast pairing with you.