### PR TITLE
Handle `return` when arg is an `Array`

### DIFF
--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -2076,7 +2076,7 @@ module SyntaxTree
               end
             elsif part.is_a?(ArrayLiteral)
               q.text(" ")
-              q.format(arguments)
+              q.format(part.contents)
             else
               format_arguments(q, "(", ")")
             end
@@ -2088,6 +2088,7 @@ module SyntaxTree
     end
 
     private
+
 
     def format_arguments(q, opening, closing)
       q.if_break { q.text(opening) }
@@ -2101,7 +2102,7 @@ module SyntaxTree
 
     def skip_parens?(node)
       case node
-      in Int | FloatLiteral
+      in Int | FloatLiteral | ArrayLiteral
         true
       in VarRef[value: GVar | IVar | CVar | Kw | Const]
         true
@@ -2525,7 +2526,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -3810,7 +3811,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -3840,7 +3841,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -3872,7 +3873,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -5313,7 +5314,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -6438,7 +6439,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -6538,7 +6539,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -6599,7 +6600,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -6624,7 +6625,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -6695,7 +6696,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { beginning: beginning, parts: parts, location: location }
     end
@@ -6728,7 +6729,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -6762,7 +6763,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -7248,7 +7249,7 @@ module SyntaxTree
       @value = value
       @location = location
     end
-  
+
     def accept(visitor)
       visitor.visit_rparen(self)
     end
@@ -7258,7 +7259,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -7513,7 +7514,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { parts: parts, location: location }
     end
@@ -7810,7 +7811,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -7840,7 +7841,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -7971,7 +7972,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -8000,7 +8001,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -8030,7 +8031,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -8141,7 +8142,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -8219,7 +8220,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -9244,7 +9245,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { value: value, location: location }
     end
@@ -9273,7 +9274,7 @@ module SyntaxTree
     end
 
     alias deconstruct child_nodes
-    
+
     def deconstruct_keys(keys)
       { parts: parts, location: location }
     end

--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -2076,7 +2076,11 @@ module SyntaxTree
               end
             elsif part.is_a?(ArrayLiteral)
               q.text(" ")
-              q.format(part.contents)
+              if part.contents && part.contents.parts.length > 1
+                q.format(part.contents)
+              else
+                q.format(arguments)
+              end
             else
               format_arguments(q, "(", ")")
             end

--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -2068,7 +2068,9 @@ module SyntaxTree
             if part.is_a?(Paren)
               if part.contents.body.length == 1 && skip_parens?(part.contents.body.first)
                 q.text(" ")
-                q.format(part.contents.body.first)
+                contents = part.contents.body.first
+                contents = contents.contents if contents.is_a?(ArrayLiteral)
+                q.format(contents)
               else
                 q.format(arguments)
               end

--- a/test/fixtures/return.rb
+++ b/test/fixtures/return.rb
@@ -33,3 +33,7 @@ return 1, 2, 3
 return [1, 2, 3]
 -
 return 1, 2, 3
+%
+return []
+%
+return [1]

--- a/test/fixtures/return.rb
+++ b/test/fixtures/return.rb
@@ -29,3 +29,7 @@ return(
 return([1, 2, 3])
 -
 return 1, 2, 3
+%
+return [1, 2, 3]
+-
+return 1, 2, 3

--- a/test/fixtures/return.rb
+++ b/test/fixtures/return.rb
@@ -25,3 +25,7 @@ return(
   foo
   bar
 )
+%
+return([1, 2, 3])
+-
+return 1, 2, 3


### PR DESCRIPTION
This PR takes care of handling `return` nodes when argument isn Array, with or without being wrapped in parens (bonus mode!).

TBH I spent more time messing with this code then actually fixing it. I dont love how it's handling `ArrayLiterals` inside `Parens` but everything else I came up with seemed like overkill or an unnecessary abstraction. I'll trust you to make the call on if this code needs to change (which I'm happy to pair on) but for now I wanted to get it working before getting it "right" (or fast)