### PR TITLE
Remove argument forwarding

### DIFF
--- a/lib/syntax_tree/formatter.rb
+++ b/lib/syntax_tree/formatter.rb
@@ -9,8 +9,8 @@ module SyntaxTree
 
     attr_reader :source, :stack, :quote
 
-    def initialize(source, ...)
-      super(...)
+    def initialize(source, *args)
+      super(*args)
 
       @source = source
       @stack = []


### PR DESCRIPTION
Argument forwarding with leading positional arguments doesn't work in Ruby 2.7, which makes SyntaxTree break upon require when using that Ruby version.