### PR TITLE
RuboCop

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,9 +24,26 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Test
       run: bundle exec rake test
+
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+    - uses: actions/checkout@master
+    - uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+        ruby-version: '3.1'
+    - name: Check
+      run: bundle exec rake check
+
   automerge:
     name: AutoMerge
-    needs: ci
+    needs:
+    - ci
+    - check
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,9 @@ jobs:
         bundler-cache: true
         ruby-version: '3.1'
     - name: Check
-      run: bundle exec rake check
+      run: |
+        bundle exec rake check
+        bundle exec rubocop
 
   automerge:
     name: AutoMerge

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,9 +12,6 @@ AllCops:
 
 Layout/LineLength:
   Max: 80
-  AllowedPatterns:
-  - '^\s*in '
-  - '^\s*location: Location'
 
 Lint/DuplicateBranch:
   Enabled: false
@@ -24,6 +21,9 @@ Lint/InterpolationCheck:
 
 Lint/MissingSuper:
   Enabled: false
+
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: true
 
 Metrics:
   Enabled: false
@@ -71,18 +71,4 @@ Style/PerlBackrefs:
   Enabled: false
 
 Style/SpecialGlobalVars:
-  Enabled: false
-
-###
-
-Lint/AssignmentInCondition:
-  Enabled: false
-
-Lint/UnusedMethodArgument:
-  Enabled: false
-
-Style/Documentation:
-  Enabled: false
-
-Style/StringLiterals:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,9 @@ Style/GuardClause:
 Style/IdenticalConditionalBranches:
   Enabled: false
 
+Style/IfInsideElse:
+  Enabled: false
+
 Style/KeywordParametersOrder:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,85 @@
+inherit_from: config/rubocop.yml
+
+AllCops:
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+  NewCops: enable
+  SuggestExtensions: false
+  TargetRubyVersion: 2.7
+  Exclude:
+  - '{bin,coverage,pkg,test/fixtures,vendor,tmp}/**/*'
+  - test.rb
+
+Layout/LineLength:
+  Max: 80
+  AllowedPatterns:
+  - '^\s*in '
+  - '^\s*location: Location'
+
+Lint/DuplicateBranch:
+  Enabled: false
+
+Lint/InterpolationCheck:
+  Enabled: false
+
+Lint/MissingSuper:
+  Enabled: false
+
+Metrics:
+  Enabled: false
+
+Naming/MethodName:
+  Enabled: false
+
+Naming/MethodParameterName:
+  Enabled: false
+
+Naming/RescuedExceptionsVariableName:
+  PreferredName: error
+
+Style/ExplicitBlockArgument:
+  Enabled: false
+
+Style/FormatString:
+  EnforcedStyle: percent
+
+Style/GuardClause:
+  Enabled: false
+
+Style/IdenticalConditionalBranches:
+  Enabled: false
+
+Style/KeywordParametersOrder:
+  Enabled: false
+
+Style/MutableConstant:
+  Enabled: false
+
+Style/NegatedIfElseCondition:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/ParallelAssignment:
+  Enabled: false
+
+Style/PerlBackrefs:
+  Enabled: false
+
+Style/SpecialGlobalVars:
+  Enabled: false
+
+###
+
+Lint/AssignmentInCondition:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,15 +6,35 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
     docile (1.4.0)
     minitest (5.15.0)
+    parallel (1.22.1)
+    parser (3.1.2.0)
+      ast (~> 2.4.1)
+    rainbow (3.1.1)
     rake (13.0.6)
+    regexp_parser (2.3.1)
+    rexml (3.2.5)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.17.0)
+      parser (>= 3.1.1.0)
+    ruby-progressbar (1.11.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    unicode-display_width (2.1.0)
 
 PLATFORMS
   arm64-darwin-21
@@ -27,6 +47,7 @@ DEPENDENCIES
   bundler
   minitest
   rake
+  rubocop
   simplecov
   syntax_tree!
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ It is built with only standard library dependencies. It additionally ships with 
   - [ast](#ast)
   - [check](#check)
   - [format](#format)
+  - [json](#json)
+  - [match](#match)
   - [write](#write)
 - [Library](#library)
   - [SyntaxTree.read(filepath)](#syntaxtreereadfilepath)
@@ -34,6 +36,9 @@ It is built with only standard library dependencies. It additionally ships with 
   - [textDocument/inlayHints](#textdocumentinlayhints)
   - [syntaxTree/visualizing](#syntaxtreevisualizing)
 - [Plugins](#plugins)
+- [Integration](#integration)
+  - [RuboCop](#rubocop)
+  - [VSCode](#vscode)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -394,6 +399,25 @@ Below are listed all of the "official" plugins hosted under the same GitHub orga
 * [SyntaxTree::Haml](https://github.com/ruby-syntax-tree/syntax_tree-haml) for the [Haml template language](https://haml.info/).
 * [SyntaxTree::JSON](https://github.com/ruby-syntax-tree/syntax_tree-json) for JSON.
 * [SyntaxTree::RBS](https://github.com/ruby-syntax-tree/syntax_tree-rbs) for the [RBS type language](https://github.com/ruby/rbs).
+
+When invoking the CLI, you pass through the list of plugins with the `--plugins` options to the commands that accept them. They should be a comma-delimited list. When the CLI first starts, it will require the files corresponding to those names.
+
+## Integration
+
+Syntax Tree's goal is to seemlessly integrate into your workflow. To this end, it provides a couple of additional tools beyond the CLI and the Ruby library.
+
+### RuboCop
+
+RuboCop and Syntax Tree serve different purposes, but there is overlap with some of RuboCop's functionality. Syntax Tree provides a RuboCop configuration file to disable rules that are redundant with Syntax Tree. To use this configuration file, add the following snippet to the top of your project's `.rubocop.yml`:
+
+```yaml
+inherit_gem:
+  syntax_tree: config/rubocop.yml
+```
+
+### VSCode
+
+To integrate Syntax Tree into VSCode, you should use the official VSCode extension [ruby-syntax-tree/vscode-syntax-tree](https://github.com/ruby-syntax-tree/vscode-syntax-tree).
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'bundler/gem_tasks'
-require 'rake/testtask'
+require "bundler/gem_tasks"
+require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << 'test'
-  t.libs << 'lib'
-  t.test_files = FileList['test/**/*_test.rb']
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/*_test.rb"]
 end
 
 task default: :test

--- a/Rakefile
+++ b/Rakefile
@@ -10,3 +10,25 @@ Rake::TestTask.new(:test) do |t|
 end
 
 task default: :test
+
+FILEPATHS = %w[
+  Gemfile
+  Rakefile
+  syntax_tree.gemspec
+  lib/**/*.rb
+  test/*.rb
+].freeze
+
+task :syntax_tree do
+  $:.unshift File.expand_path("lib", __dir__)
+  require "syntax_tree"
+  require "syntax_tree/cli"
+end
+
+task check: :syntax_tree do
+  exit SyntaxTree::CLI.run(["check"] + FILEPATHS)
+end
+
+task format: :syntax_tree do
+  exit SyntaxTree::CLI.run(["write"] + FILEPATHS)
+end

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -9,13 +9,8 @@ Layout:
 #
 # Users can always override these defaults in their own rubocop.yml files.
 # https://github.com/prettier/plugin-ruby/issues/825
-#
-# We're also explicitly allowing pattern matching to extend beyond the maximum
-# line length, since SyntaxTree prefers putting patterns on a single line.
 Layout/LineLength:
   Enabled: true
-  AllowedPatterns:
-  - '^\s*in '
 
 Style/MultilineIfModifier:
   Enabled: false

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,0 +1,69 @@
+# Disabling all Layout/* rules, as they're unnecessary when the user is using
+# Syntax Tree to handle all of the formatting.
+Layout:
+  Enabled: false
+
+# Re-enable Layout/LineLength because certain cops that most projects use
+# (e.g. Style/IfUnlessModifier) require Layout/LineLength to be enabled.
+# By leaving it disabled, those rules will mis-fire.
+#
+# Users can always override these defaults in their own rubocop.yml files.
+# https://github.com/prettier/plugin-ruby/issues/825
+#
+# We're also explicitly allowing pattern matching to extend beyond the maximum
+# line length, since SyntaxTree prefers putting patterns on a single line.
+Layout/LineLength:
+  Enabled: true
+  AllowedPatterns:
+  - '^\s*in '
+
+Style/MultilineIfModifier:
+  Enabled: false
+
+# Syntax Tree will expand empty methods to put the end keyword on the subsequent
+# line to reduce git diff noise.
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
+# lambdas that are constructed with the lambda method call cannot be safely
+# turned into lambda literals without removing a method call.
+Style/Lambda:
+  Enabled: false
+
+# When method chains with multiple blocks are chained together, rubocop will let
+# them pass if they're using braces but not if they're using do and end
+# keywords. Because we will break individual blocks down to using keywords if
+# they are multiline, this conflicts with rubocop.
+Style/MultilineBlockChain:
+  Enabled: false
+
+# Syntax Tree by default uses double quotes, so changing the configuration here
+# to match that.
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+Style/QuotedSymbols:
+  EnforcedStyle: double_quotes
+
+# We let users have a little more freedom with symbol and words arrays. If the
+# user only has an individual item like ["value"] then we don't bother
+# converting it because it ends up being just noise.
+Style/SymbolArray:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false
+
+# We don't support trailing commas in Syntax Tree by default, so just turning
+# these off for now.
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false

--- a/lib/syntax_tree.rb
+++ b/lib/syntax_tree.rb
@@ -30,6 +30,10 @@ unless PrettyPrint.const_defined?(:Align)
   end
 end
 
+# Syntax Tree is a suite of tools built on top of the internal CRuby parser. It
+# provides the ability to generate a syntax tree from source, as well as the
+# tools necessary to inspect and manipulate that syntax tree. It can be used to
+# build formatters, linters, language servers, and more.
 module SyntaxTree
   # This holds references to objects that respond to both #parse and #format
   # so that we can use them in the CLI.

--- a/lib/syntax_tree/cli.rb
+++ b/lib/syntax_tree/cli.rb
@@ -242,7 +242,7 @@ module SyntaxTree
 
         # If we're not reading from stdin and the user didn't supply and
         # filepaths to be read, then we exit with the usage message.
-        if STDIN.tty? && arguments.empty?
+        if $stdin.tty? && arguments.empty?
           warn(HELP)
           return 1
         end
@@ -280,7 +280,7 @@ module SyntaxTree
           errored = true
         rescue Check::UnformattedError, Debug::NonIdempotentFormatError
           errored = true
-        rescue => error
+        rescue StandardError => error
           warn(error.message)
           warn(error.backtrace)
           errored = true
@@ -298,7 +298,7 @@ module SyntaxTree
       private
 
       def each_file(arguments)
-        if STDIN.tty?
+        if $stdin.tty?
           arguments.each do |pattern|
             Dir.glob(pattern).each do |filepath|
               next unless File.file?(filepath)
@@ -309,7 +309,7 @@ module SyntaxTree
             end
           end
         else
-          yield HANDLERS[".rb"], :stdin, STDIN.read
+          yield HANDLERS[".rb"], :stdin, $stdin.read
         end
       end
 

--- a/lib/syntax_tree/cli.rb
+++ b/lib/syntax_tree/cli.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module SyntaxTree
+  # Syntax Tree ships with the `stree` CLI, which can be used to inspect and
+  # manipulate Ruby code. This module is responsible for powering that CLI.
   module CLI
     # A utility wrapper around colored strings in the output.
     class Color
@@ -46,7 +48,7 @@ module SyntaxTree
 
     # An action of the CLI that prints out the AST for the given source.
     class AST < Action
-      def run(handler, filepath, source)
+      def run(handler, _filepath, source)
         pp handler.parse(source)
       end
     end
@@ -100,7 +102,7 @@ module SyntaxTree
 
     # An action of the CLI that prints out the doc tree IR for the given source.
     class Doc < Action
-      def run(handler, filepath, source)
+      def run(handler, _filepath, source)
         formatter = Formatter.new(source, [])
         handler.parse(source).format(formatter)
         pp formatter.groups.first
@@ -109,7 +111,7 @@ module SyntaxTree
 
     # An action of the CLI that formats the input source and prints it out.
     class Format < Action
-      def run(handler, filepath, source)
+      def run(handler, _filepath, source)
         puts handler.format(source)
       end
     end
@@ -117,7 +119,7 @@ module SyntaxTree
     # An action of the CLI that converts the source into its equivalent JSON
     # representation.
     class Json < Action
-      def run(handler, filepath, source)
+      def run(handler, _filepath, source)
         object = Visitor::JSONVisitor.new.visit(handler.parse(source))
         puts JSON.pretty_generate(object)
       end
@@ -126,7 +128,7 @@ module SyntaxTree
     # An action of the CLI that outputs a pattern-matching Ruby expression that
     # would match the input given.
     class Match < Action
-      def run(handler, filepath, source)
+      def run(handler, _filepath, source)
         formatter = Formatter.new(source, [])
         Visitor::MatchVisitor.new(formatter).visit(handler.parse(source))
         formatter.flush
@@ -296,7 +298,7 @@ module SyntaxTree
       private
 
       def each_file(arguments)
-        if $stdin.tty?
+        if $stdin.tty? || arguments.any?
           arguments.each do |pattern|
             Dir
               .glob(pattern)

--- a/lib/syntax_tree/cli.rb
+++ b/lib/syntax_tree/cli.rb
@@ -83,9 +83,7 @@ module SyntaxTree
         warning = "[#{Color.yellow("warn")}] #{filepath}"
         formatted = handler.format(source)
 
-        if formatted != handler.format(formatted)
-          raise NonIdempotentFormatError
-        end
+        raise NonIdempotentFormatError if formatted != handler.format(formatted)
       rescue StandardError
         warn(warning)
         raise
@@ -300,13 +298,15 @@ module SyntaxTree
       def each_file(arguments)
         if $stdin.tty?
           arguments.each do |pattern|
-            Dir.glob(pattern).each do |filepath|
-              next unless File.file?(filepath)
+            Dir
+              .glob(pattern)
+              .each do |filepath|
+                next unless File.file?(filepath)
 
-              handler = HANDLERS[File.extname(filepath)]
-              source = handler.read(filepath)
-              yield handler, filepath, source
-            end
+                handler = HANDLERS[File.extname(filepath)]
+                source = handler.read(filepath)
+                yield handler, filepath, source
+              end
           end
         else
           yield HANDLERS[".rb"], :stdin, $stdin.read

--- a/lib/syntax_tree/formatter.rb
+++ b/lib/syntax_tree/formatter.rb
@@ -41,11 +41,12 @@ module SyntaxTree
 
         # If the node has a stree-ignore comment right before it, then we're
         # going to just print out the node as it was seen in the source.
-        if leading.last&.ignore?
-          doc = text(source[node.location.start_char...node.location.end_char])
-        else
-          doc = node.format(self)
-        end
+        doc =
+          if leading.last&.ignore?
+            text(source[node.location.start_char...node.location.end_char])
+          else
+            node.format(self)
+          end
 
         # Print all comments that were found after the node.
         trailing.each do |comment|

--- a/lib/syntax_tree/language_server.rb
+++ b/lib/syntax_tree/language_server.rb
@@ -7,6 +7,11 @@ require "uri"
 require_relative "language_server/inlay_hints"
 
 module SyntaxTree
+  # Syntax Tree additionally ships with a language server conforming to the
+  # language server protocol. It can be invoked through the CLI by running:
+  #
+  #     stree lsp
+  #
   class LanguageServer
     attr_reader :input, :output
 
@@ -21,7 +26,7 @@ module SyntaxTree
           hash[uri] = File.binread(CGI.unescape(URI.parse(uri).path))
         end
 
-      while headers = input.gets("\r\n\r\n")
+      while (headers = input.gets("\r\n\r\n"))
         source = input.read(headers[/Content-Length: (\d+)/i, 1].to_i)
         request = JSON.parse(source, symbolize_names: true)
 

--- a/lib/syntax_tree/language_server.rb
+++ b/lib/syntax_tree/language_server.rb
@@ -29,9 +29,9 @@ module SyntaxTree
         in { method: "initialize", id: }
           store.clear
           write(id: id, result: { capabilities: capabilities })
-        in { method: "initialized" }
+        in method: "initialized"
           # ignored
-        in { method: "shutdown" }
+        in method: "shutdown"
           store.clear
           return
         in {
@@ -68,7 +68,7 @@ module SyntaxTree
           output = []
           PP.pp(SyntaxTree.parse(store[uri]), output)
           write(id: id, result: output.join)
-        in { method: %r{\$/.+} }
+        in method: %r{\$/.+}
           # ignored
         else
           raise "Unhandled: #{request}"

--- a/lib/syntax_tree/language_server.rb
+++ b/lib/syntax_tree/language_server.rb
@@ -34,17 +34,37 @@ module SyntaxTree
         in { method: "shutdown" }
           store.clear
           return
-        in { method: "textDocument/didChange", params: { textDocument: { uri: }, contentChanges: [{ text: }, *] } }
+        in {
+             method: "textDocument/didChange",
+             params: { textDocument: { uri: }, contentChanges: [{ text: }, *] }
+           }
           store[uri] = text
-        in { method: "textDocument/didOpen", params: { textDocument: { uri:, text: } } }
+        in {
+             method: "textDocument/didOpen",
+             params: { textDocument: { uri:, text: } }
+           }
           store[uri] = text
-        in { method: "textDocument/didClose", params: { textDocument: { uri: } } }
+        in {
+             method: "textDocument/didClose", params: { textDocument: { uri: } }
+           }
           store.delete(uri)
-        in { method: "textDocument/formatting", id:, params: { textDocument: { uri: } } }
+        in {
+             method: "textDocument/formatting",
+             id:,
+             params: { textDocument: { uri: } }
+           }
           write(id: id, result: [format(store[uri])])
-        in { method: "textDocument/inlayHints", id:, params: { textDocument: { uri: } } }
+        in {
+             method: "textDocument/inlayHints",
+             id:,
+             params: { textDocument: { uri: } }
+           }
           write(id: id, result: inlay_hints(store[uri]))
-        in { method: "syntaxTree/visualizing", id:, params: { textDocument: { uri: } } }
+        in {
+             method: "syntaxTree/visualizing",
+             id:,
+             params: { textDocument: { uri: } }
+           }
           output = []
           PP.pp(SyntaxTree.parse(store[uri]), output)
           write(id: id, result: output.join)
@@ -61,15 +81,24 @@ module SyntaxTree
     def capabilities
       {
         documentFormattingProvider: true,
-        textDocumentSync: { change: 1, openClose: true }
+        textDocumentSync: {
+          change: 1,
+          openClose: true
+        }
       }
     end
 
     def format(source)
       {
         range: {
-          start: { line: 0, character: 0 },
-          end: { line: source.lines.size + 1, character: 0 }
+          start: {
+            line: 0,
+            character: 0
+          },
+          end: {
+            line: source.lines.size + 1,
+            character: 0
+          }
         },
         newText: SyntaxTree.format(source)
       }

--- a/lib/syntax_tree/language_server.rb
+++ b/lib/syntax_tree/language_server.rb
@@ -10,7 +10,7 @@ module SyntaxTree
   class LanguageServer
     attr_reader :input, :output
 
-    def initialize(input: STDIN, output: STDOUT)
+    def initialize(input: $stdin, output: $stdout)
       @input = input.binmode
       @output = output.binmode
     end
@@ -88,6 +88,8 @@ module SyntaxTree
         after: inlay_hints.after.map(&serialize)
       }
     rescue Parser::ParseError
+      # If there is a parse error, then we're not going to return any inlay
+      # hints for this source.
     end
 
     def write(value)

--- a/lib/syntax_tree/language_server/inlay_hints.rb
+++ b/lib/syntax_tree/language_server/inlay_hints.rb
@@ -2,6 +2,13 @@
 
 module SyntaxTree
   class LanguageServer
+    # This class provides inlay hints for the language server. It is loosely
+    # designed around the LSP spec, but existed before the spec was finalized so
+    # is a little different for now.
+    #
+    # For more information, see the spec here:
+    # https://github.com/microsoft/language-server-protocol/issues/956.
+    #
     class InlayHints < Visitor
       attr_reader :stack, :before, :after
 

--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -51,7 +51,7 @@ module SyntaxTree
       [start_line, start_char, start_column, end_line, end_char, end_column]
     end
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         start_line: start_line,
         start_char: start_char,
@@ -159,7 +159,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         lbrace: lbrace,
         statements: statements,
@@ -211,7 +211,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -262,7 +262,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         lbrace: lbrace,
         statements: statements,
@@ -317,7 +317,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -342,6 +342,8 @@ module SyntaxTree
   # symbols (note that this includes dynamic symbols like
   # :"left-#{middle}-right").
   class Alias < Node
+    # Formats an argument to the alias keyword. For symbol literals it uses the
+    # value of the symbol directly to look like bare words.
     class AliasArgumentFormatter
       # [DynaSymbol | SymbolLiteral] the argument being passed to alias
       attr_reader :argument
@@ -393,7 +395,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { left: left, right: right, location: location, comments: comments }
     end
 
@@ -454,7 +456,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         collection: collection,
         index: index,
@@ -515,7 +517,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         collection: collection,
         index: index,
@@ -577,7 +579,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { arguments: arguments, location: location, comments: comments }
     end
 
@@ -625,7 +627,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { parts: parts, location: location, comments: comments }
     end
 
@@ -661,7 +663,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -698,7 +700,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -748,7 +750,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -764,6 +766,7 @@ module SyntaxTree
   #     [one, two, three]
   #
   class ArrayLiteral < Node
+    # Formats an array of multiple simple string literals into the %w syntax.
     class QWordsFormatter
       # [Args] the contents of the array
       attr_reader :contents
@@ -789,6 +792,7 @@ module SyntaxTree
       end
     end
 
+    # Formats an array of multiple simple symbol literals into the %i syntax.
     class QSymbolsFormatter
       # [Args] the contents of the array
       attr_reader :contents
@@ -810,6 +814,28 @@ module SyntaxTree
       end
     end
 
+    # Formats an array that contains only a list of variable references. To make
+    # things simpler, if there are a bunch, we format them all using the "fill"
+    # algorithm as opposed to breaking them into a ton of lines. For example,
+    #
+    #     [foo, bar, baz]
+    #
+    # instead of becoming:
+    #
+    #     [
+    #       foo,
+    #       bar,
+    #       baz
+    #     ]
+    #
+    # would instead become:
+    #
+    #     [
+    #       foo, bar,
+    #       baz
+    #     ]
+    #
+    # provided the line length was hit between `bar` and `baz`.
     class VarRefsFormatter
       # [Args] the contents of the array
       attr_reader :contents
@@ -835,6 +861,9 @@ module SyntaxTree
       end
     end
 
+    # This is a special formatter used if the array literal contains no values
+    # but _does_ contain comments. In this case we do some special formatting to
+    # make sure the comments gets indented properly.
     class EmptyWithCommentsFormatter
       # [LBracket] the opening bracket
       attr_reader :lbracket
@@ -884,7 +913,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         lbracket: lbracket,
         contents: contents,
@@ -993,6 +1022,7 @@ module SyntaxTree
   # and an optional array of positional matches that occur after the splat.
   # All of the in clauses above would create an AryPtn node.
   class AryPtn < Node
+    # Formats the optional splat of an array pattern.
     class RestFormatter
       # [VarField] the identifier that represents the remaining positionals
       attr_reader :value
@@ -1055,7 +1085,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         constant: constant,
         requireds: requireds,
@@ -1146,7 +1176,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { target: target, value: value, location: location, comments: comments }
     end
 
@@ -1208,7 +1238,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { key: key, value: value, location: location, comments: comments }
     end
 
@@ -1266,7 +1296,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -1304,7 +1334,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -1339,7 +1369,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -1352,6 +1382,7 @@ module SyntaxTree
   # hash or bare hash. It first determines if every key in the hash can use
   # labels. If it can, it uses labels. Otherwise it uses hash rockets.
   module HashKeyFormatter
+    # Formats the keys of a hash literal using labels.
     class Labels
       def format_key(q, key)
         case key
@@ -1367,6 +1398,7 @@ module SyntaxTree
       end
     end
 
+    # Formats the keys of a hash literal using hash rockets.
     class Rockets
       def format_key(q, key)
         case key
@@ -1440,7 +1472,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { assocs: assocs, location: location, comments: comments }
     end
 
@@ -1482,7 +1514,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { bodystmt: bodystmt, location: location, comments: comments }
     end
 
@@ -1530,7 +1562,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { statement: statement, location: location, comments: comments }
     end
 
@@ -1590,7 +1622,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         left: left,
         operator: operator,
@@ -1705,7 +1737,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { params: params, locals: locals, location: location, comments: comments }
     end
 
@@ -1749,7 +1781,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { name: name, location: location, comments: comments }
     end
 
@@ -1845,7 +1877,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         statements: statements,
         rescue_clause: rescue_clause,
@@ -1891,6 +1923,7 @@ module SyntaxTree
 
   # Responsible for formatting either a BraceBlock or a DoBlock.
   class BlockFormatter
+    # Formats the opening brace or keyword of a block.
     class BlockOpenFormatter
       # [String] the actual output that should be printed
       attr_reader :text
@@ -2083,7 +2116,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         lbrace: lbrace,
         block_var: block_var,
@@ -2282,7 +2315,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { arguments: arguments, location: location, comments: comments }
     end
 
@@ -2314,6 +2347,20 @@ module SyntaxTree
     end
   end
 
+  # This is probably the most complicated formatter in this file. It's
+  # responsible for formatting chains of method calls, with or without arguments
+  # or blocks. In general, we want to go from something like
+  #
+  #     foo.bar.baz
+  #
+  # to
+  #
+  #     foo
+  #       .bar
+  #       .baz
+  #
+  # Of course there are a lot of caveats to that, including trailing operators
+  # when necessary, where comments are places, how blocks are aligned, etc.
   class CallChainFormatter
     # [Call | MethodAddBlock] the top of the call chain
     attr_reader :node
@@ -2348,7 +2395,7 @@ module SyntaxTree
       # block. For more details, see
       # https://github.com/prettier/plugin-ruby/issues/863.
       parents = q.parents.take(4)
-      if parent = parents[2]
+      if (parent = parents[2])
         # If we're at a do_block, then we want to go one more level up. This is
         # because do blocks have BodyStmt nodes instead of just Statements
         # nodes.
@@ -2399,7 +2446,7 @@ module SyntaxTree
           # and a trailing operator.
           skip_operator = false
 
-          while child = children.pop
+          while (child = children.pop)
             case child
             in Call[
                  receiver: Call[message: { value: "where" }],
@@ -2556,7 +2603,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         receiver: receiver,
         operator: operator,
@@ -2666,7 +2713,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         keyword: keyword,
         value: value,
@@ -2731,7 +2778,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         value: value,
         operator: operator,
@@ -2820,7 +2867,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         constant: constant,
         superclass: superclass,
@@ -2885,7 +2932,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -2923,7 +2970,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         message: message,
         arguments: arguments,
@@ -3005,7 +3052,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         receiver: receiver,
         operator: operator,
@@ -3144,7 +3191,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, inline: inline, location: location }
     end
 
@@ -3190,7 +3237,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -3232,7 +3279,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         parent: parent,
         constant: constant,
@@ -3279,7 +3326,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         parent: parent,
         constant: constant,
@@ -3324,7 +3371,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { constant: constant, location: location, comments: comments }
     end
 
@@ -3360,7 +3407,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -3404,7 +3451,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         name: name,
         params: params,
@@ -3489,7 +3536,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         target: target,
         operator: operator,
@@ -3557,7 +3604,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -3623,7 +3670,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         target: target,
         operator: operator,
@@ -3698,7 +3745,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         keyword: keyword,
         block_var: block_var,
@@ -3778,7 +3825,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { left: left, right: right, location: location, comments: comments }
     end
 
@@ -3826,7 +3873,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { left: left, right: right, location: location, comments: comments }
     end
 
@@ -3913,7 +3960,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { parts: parts, quote: quote, location: location, comments: comments }
     end
 
@@ -4013,7 +4060,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         keyword: keyword,
         statements: statements,
@@ -4079,7 +4126,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         predicate: predicate,
         statements: statements,
@@ -4151,7 +4198,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
 
@@ -4186,7 +4233,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -4216,7 +4263,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -4248,7 +4295,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -4287,7 +4334,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         keyword: keyword,
         statements: statements,
@@ -4341,7 +4388,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -4384,7 +4431,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         value: value,
         arguments: arguments,
@@ -4444,7 +4491,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         parent: parent,
         operator: operator,
@@ -4490,7 +4537,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -4542,7 +4589,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         constant: constant,
         left: left,
@@ -4606,7 +4653,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         index: index,
         collection: collection,
@@ -4663,7 +4710,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -4677,6 +4724,9 @@ module SyntaxTree
   #     { key => value }
   #
   class HashLiteral < Node
+    # This is a special formatter used if the hash literal contains no values
+    # but _does_ contain comments. In this case we do some special formatting to
+    # make sure the comments gets indented properly.
     class EmptyWithCommentsFormatter
       # [LBrace] the opening brace
       attr_reader :lbrace
@@ -4726,7 +4776,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { lbrace: lbrace, assocs: assocs, location: location, comments: comments }
     end
 
@@ -4821,7 +4871,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         beginning: beginning,
         location: location,
@@ -4897,7 +4947,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -4914,6 +4964,7 @@ module SyntaxTree
   #     end
   #
   class HshPtn < Node
+    # Formats a key-value pair in a hash pattern. The value is optional.
     class KeywordFormatter
       # [Label] the keyword being used
       attr_reader :key
@@ -4940,6 +4991,7 @@ module SyntaxTree
       end
     end
 
+    # Formats the optional double-splat from the pattern.
     class KeywordRestFormatter
       # [VarField] the parameter that matches the remaining keywords
       attr_reader :keyword_rest
@@ -4989,7 +5041,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         constant: constant,
         keywords: keywords,
@@ -5087,7 +5139,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -5104,7 +5156,7 @@ module SyntaxTree
     def self.call(parent)
       queue = [parent]
 
-      while node = queue.shift
+      while (node = queue.shift)
         return true if [Assign, MAssign, OpAssign].include?(node.class)
         queue += node.child_nodes
       end
@@ -5339,7 +5391,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         predicate: predicate,
         statements: statements,
@@ -5389,7 +5441,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         predicate: predicate,
         truthy: truthy,
@@ -5528,7 +5580,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         statement: statement,
         predicate: predicate,
@@ -5569,7 +5621,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -5616,7 +5668,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         pattern: pattern,
         statements: statements,
@@ -5675,7 +5727,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -5719,7 +5771,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -5764,7 +5816,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -5801,7 +5853,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { name: name, location: location, comments: comments }
     end
 
@@ -5847,7 +5899,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -5882,7 +5934,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -5918,7 +5970,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         params: params,
         statements: statements,
@@ -5989,7 +6041,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -6022,7 +6074,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -6055,7 +6107,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -6105,7 +6157,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { target: target, value: value, location: location, comments: comments }
     end
 
@@ -6152,7 +6204,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { call: call, block: block, location: location, comments: comments }
     end
 
@@ -6213,7 +6265,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { parts: parts, location: location, comma: comma, comments: comments }
     end
 
@@ -6257,7 +6309,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { contents: contents, location: location, comments: comments }
     end
 
@@ -6313,7 +6365,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         constant: constant,
         bodystmt: bodystmt,
@@ -6380,7 +6432,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { parts: parts, location: location, comments: comments }
     end
 
@@ -6429,7 +6481,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { arguments: arguments, location: location, comments: comments }
     end
 
@@ -6466,7 +6518,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -6512,7 +6564,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         target: target,
         operator: operator,
@@ -6621,6 +6673,8 @@ module SyntaxTree
   #     def method(param) end
   #
   class Params < Node
+    # Formats the optional position of the parameters. This includes the label,
+    # as well as the default value.
     class OptionalFormatter
       # [Ident] the name of the parameter
       attr_reader :name
@@ -6644,6 +6698,8 @@ module SyntaxTree
       end
     end
 
+    # Formats the keyword position of the parameters. This includes the label,
+    # as well as an optional default value.
     class KeywordFormatter
       # [Ident] the name of the parameter
       attr_reader :name
@@ -6670,6 +6726,8 @@ module SyntaxTree
       end
     end
 
+    # Formats the keyword_rest position of the parameters. This can be the **nil
+    # syntax, the ... syntax, or the ** syntax.
     class KeywordRestFormatter
       # [:nil | ArgsForward | KwRestParam] the value of the parameter
       attr_reader :value
@@ -6764,7 +6822,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         location: location,
         requireds: requireds,
@@ -6845,7 +6903,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         lparen: lparen,
         contents: contents,
@@ -6896,7 +6954,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -6929,7 +6987,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { statements: statements, location: location, comments: comments }
     end
 
@@ -6974,7 +7032,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         beginning: beginning,
         elements: elements,
@@ -7029,7 +7087,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
 
@@ -7074,7 +7132,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         beginning: beginning,
         elements: elements,
@@ -7129,7 +7187,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -7161,7 +7219,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -7190,7 +7248,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -7215,7 +7273,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -7247,7 +7305,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -7286,7 +7344,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { beginning: beginning, parts: parts, location: location }
     end
   end
@@ -7319,7 +7377,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -7353,7 +7411,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -7394,7 +7452,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         beginning: beginning,
         ending: ending,
@@ -7499,7 +7557,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         exceptions: exceptions,
         variable: variable,
@@ -7593,7 +7651,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         keyword: keyword,
         exception: exception,
@@ -7660,7 +7718,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         statement: statement,
         value: value,
@@ -7714,7 +7772,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { name: name, location: location, comments: comments }
     end
 
@@ -7751,7 +7809,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -7787,7 +7845,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { arguments: arguments, location: location, comments: comments }
     end
 
@@ -7823,7 +7881,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -7852,7 +7910,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -7891,7 +7949,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         target: target,
         bodystmt: bodystmt,
@@ -7993,7 +8051,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { parser: parser, body: body, location: location, comments: comments }
     end
 
@@ -8115,7 +8173,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { parts: parts, location: location }
     end
   end
@@ -8153,14 +8211,14 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { left: left, right: right, location: location, comments: comments }
     end
 
     def format(q)
       q.group do
         q.format(left)
-        q.text(' \\')
+        q.text(" \\")
         q.indent do
           q.breakable(force: true)
           q.format(right)
@@ -8198,7 +8256,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { variable: variable, location: location, comments: comments }
     end
 
@@ -8238,7 +8296,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { statements: statements, location: location, comments: comments }
     end
 
@@ -8296,7 +8354,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { parts: parts, quote: quote, location: location, comments: comments }
     end
 
@@ -8359,7 +8417,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { arguments: arguments, location: location, comments: comments }
     end
 
@@ -8412,7 +8470,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -8442,7 +8500,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -8476,7 +8534,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -8517,7 +8575,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         beginning: beginning,
         elements: elements,
@@ -8573,7 +8631,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -8602,7 +8660,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -8632,7 +8690,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -8666,7 +8724,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { constant: constant, location: location, comments: comments }
     end
 
@@ -8704,7 +8762,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { constant: constant, location: location, comments: comments }
     end
 
@@ -8743,7 +8801,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -8783,7 +8841,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -8821,7 +8879,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -8857,7 +8915,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         statement: statement,
         parentheses: parentheses,
@@ -8924,7 +8982,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         operator: operator,
         statement: statement,
@@ -8944,6 +9002,9 @@ module SyntaxTree
   #     undef method
   #
   class Undef < Node
+    # Undef accepts a variable number of arguments that can be either DynaSymbol
+    # or SymbolLiteral objects. For SymbolLiteral objects we descend directly
+    # into the value in order to have it come out as bare words.
     class UndefArgumentFormatter
       # [DynaSymbol | SymbolLiteral] the symbol to undefine
       attr_reader :node
@@ -8987,7 +9048,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { symbols: symbols, location: location, comments: comments }
     end
 
@@ -9046,7 +9107,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         predicate: predicate,
         statements: statements,
@@ -9092,7 +9153,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         statement: statement,
         predicate: predicate,
@@ -9189,7 +9250,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         predicate: predicate,
         statements: statements,
@@ -9245,7 +9306,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         statement: statement,
         predicate: predicate,
@@ -9311,7 +9372,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { left: left, right: right, location: location, comments: comments }
     end
 
@@ -9354,7 +9415,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -9398,7 +9459,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -9439,7 +9500,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -9479,7 +9540,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -9514,7 +9575,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { location: location, comments: comments }
     end
 
@@ -9565,7 +9626,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         arguments: arguments,
         statements: statements,
@@ -9646,7 +9707,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         predicate: predicate,
         statements: statements,
@@ -9702,7 +9763,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         statement: statement,
         predicate: predicate,
@@ -9771,7 +9832,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { parts: parts, location: location, comments: comments }
     end
 
@@ -9811,7 +9872,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       {
         beginning: beginning,
         elements: elements,
@@ -9867,7 +9928,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location }
     end
   end
@@ -9896,7 +9957,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { parts: parts, location: location }
     end
   end
@@ -9929,7 +9990,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { parts: parts, location: location, comments: comments }
     end
 
@@ -9967,7 +10028,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { arguments: arguments, location: location, comments: comments }
     end
 
@@ -10017,7 +10078,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 
@@ -10053,7 +10114,7 @@ module SyntaxTree
 
     alias deconstruct child_nodes
 
-    def deconstruct_keys(keys)
+    def deconstruct_keys(_keys)
       { value: value, location: location, comments: comments }
     end
 

--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -761,7 +761,7 @@ module SyntaxTree
               if part.is_a?(StringLiteral)
                 q.format(part.parts.first)
               else
-                q.text(part.value[1..-1])
+                q.text(part.value[1..])
               end
             end
           end
@@ -1190,7 +1190,7 @@ module SyntaxTree
     end
 
     def format(q)
-      if value&.is_a?(HashLiteral)
+      if value.is_a?(HashLiteral)
         format_contents(q)
       else
         q.group { format_contents(q) }
@@ -2301,7 +2301,7 @@ module SyntaxTree
 
       # First, walk down the chain until we get to the point where we're not
       # longer at a chainable node.
-      while true
+      loop do
         case children.last
         in Call[receiver: Call]
           children << children.last.receiver
@@ -3079,7 +3079,7 @@ module SyntaxTree
     end
 
     def ignore?
-      value[1..-1].strip == "stree-ignore"
+      value[1..].strip == "stree-ignore"
     end
 
     def comments
@@ -3917,7 +3917,7 @@ module SyntaxTree
         end
       elsif Quotes.locked?(self)
         if quote.start_with?(":")
-          [hash_key ? quote[1..-1] : quote, quote[1..-1]]
+          [hash_key ? quote[1..] : quote, quote[1..]]
         else
           [hash_key ? quote : ":#{quote}", quote]
         end
@@ -4967,7 +4967,7 @@ module SyntaxTree
 
   # The list of nodes that represent patterns inside of pattern matching so that
   # when a pattern is being printed it knows if it's nested.
-  PATTERNS = [AryPtn, Binary, FndPtn, HshPtn, RAssign]
+  PATTERNS = [AryPtn, Binary, FndPtn, HshPtn, RAssign].freeze
 
   # Ident represents an identifier anywhere in code. It can represent a very
   # large number of things, depending on where it is in the syntax tree.
@@ -5587,7 +5587,7 @@ module SyntaxTree
         # the values, then we're going to insert them every 3 characters
         # starting from the right.
         index = (value.length + 2) % 3
-        q.text("  #{value}"[index..-1].scan(/.../).join("_").strip)
+        q.text("  #{value}"[index..].scan(/.../).join("_").strip)
       else
         q.text(value)
       end
@@ -6475,7 +6475,7 @@ module SyntaxTree
   # This approach maintains the nice conciseness of the inline version, while
   # keeping the correct semantic meaning.
   module Parentheses
-    NODES = [Args, Assign, Assoc, Binary, Call, Defined, MAssign, OpAssign]
+    NODES = [Args, Assign, Assoc, Binary, Call, Defined, MAssign, OpAssign].freeze
 
     def self.flat(q)
       return yield unless NODES.include?(q.parent.class)
@@ -6686,7 +6686,7 @@ module SyntaxTree
 
       contents = -> do
         q.seplist(parts) { |part| q.format(part) }
-        q.format(rest) if rest && rest.is_a?(ExcessedComma)
+        q.format(rest) if rest&.is_a?(ExcessedComma)
       end
 
       if ![Def, Defs, DefEndless].include?(q.parent.class) || parts.empty?
@@ -7323,14 +7323,14 @@ module SyntaxTree
           end
 
           q.text("}")
-          q.text(ending[1..-1])
+          q.text(ending[1..])
         end
       else
         q.group do
           q.text("/")
           q.format_each(parts)
           q.text("/")
-          q.text(ending[1..-1])
+          q.text(ending[1..])
         end
       end
     end

--- a/lib/syntax_tree/parser.rb
+++ b/lib/syntax_tree/parser.rb
@@ -130,11 +130,12 @@ module SyntaxTree
       last_index = 0
 
       @source.lines.each do |line|
-        if line.size == line.bytesize
-          @line_counts << SingleByteString.new(last_index)
-        else
-          @line_counts << MultiByteString.new(last_index, line)
-        end
+        @line_counts <<
+          if line.size == line.bytesize
+            SingleByteString.new(last_index)
+          else
+            MultiByteString.new(last_index, line)
+          end
 
         last_index += line.size
       end
@@ -2043,7 +2044,13 @@ module SyntaxTree
 
     # :call-seq:
     #   on_opassign: (
-    #     (ARefField | ConstPathField | Field | TopConstField | VarField) target,
+    #     (
+    #       ARefField |
+    #       ConstPathField |
+    #       Field |
+    #       TopConstField |
+    #       VarField
+    #     ) target,
     #     Op operator,
     #     untyped value
     #   ) -> OpAssign
@@ -2118,7 +2125,7 @@ module SyntaxTree
       lparen = find_token(LParen)
       rparen = find_token(RParen)
 
-      if contents && contents.is_a?(Params)
+      if contents&.is_a?(Params)
         location = contents.location
         start_char = find_next_statement_start(lparen.location.end_char)
         location =
@@ -2703,7 +2710,7 @@ module SyntaxTree
     def on_string_literal(string)
       heredoc = @heredocs[-1]
 
-      if heredoc && heredoc.ending
+      if heredoc&.ending
         heredoc = @heredocs.pop
 
         Heredoc.new(

--- a/lib/syntax_tree/parser.rb
+++ b/lib/syntax_tree/parser.rb
@@ -1679,7 +1679,7 @@ module SyntaxTree
 
       # If there's no constant, there may be braces, so we're going to look for
       # those to get our bounds.
-      if !constant
+      unless constant
         lbrace = find_token(LBrace, consume: false)
         rbrace = find_token(RBrace, consume: false)
 

--- a/lib/syntax_tree/parser.rb
+++ b/lib/syntax_tree/parser.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module SyntaxTree
+  # Parser is a subclass of the Ripper library that subscribes to the stream of
+  # tokens and nodes coming from the parser and builds up a syntax tree.
   class Parser < Ripper
     # A special parser error so that we can get nice syntax displays on the
     # error message when prettier prints out the results.
@@ -548,7 +550,7 @@ module SyntaxTree
 
       # If there's the optional then keyword, then we'll delete that and use it
       # as the end bounds of the location.
-      if token = find_token(Kw, "then", consume: false)
+      if (token = find_token(Kw, "then", consume: false))
         tokens.delete(token)
         location = location.to(token.location)
       end
@@ -866,7 +868,7 @@ module SyntaxTree
     # :call-seq:
     #   on_case: (untyped value, untyped consequent) -> Case | RAssign
     def on_case(value, consequent)
-      if keyword = find_token(Kw, "case", consume: false)
+      if (keyword = find_token(Kw, "case", consume: false))
         tokens.delete(keyword)
 
         Case.new(
@@ -1691,7 +1693,7 @@ module SyntaxTree
       end
 
       # Delete the optional then keyword
-      if token = find_token(Kw, "then", consume: false)
+      if (token = find_token(Kw, "then", consume: false))
         parts << token
         tokens.delete(token)
       end
@@ -1805,7 +1807,7 @@ module SyntaxTree
       ending = consequent || find_token(Kw, "end")
 
       statements_start = pattern
-      if token = find_token(Kw, "then", consume: false)
+      if (token = find_token(Kw, "then", consume: false))
         tokens.delete(token)
         statements_start = token
       end
@@ -3422,7 +3424,7 @@ module SyntaxTree
       ending = consequent || find_token(Kw, "end")
 
       statements_start = arguments
-      if token = find_token(Kw, "then", consume: false)
+      if (token = find_token(Kw, "then", consume: false))
         tokens.delete(token)
         statements_start = token
       end

--- a/lib/syntax_tree/prettyprint.rb
+++ b/lib/syntax_tree/prettyprint.rb
@@ -419,9 +419,9 @@ class PrettyPrint
       target.trim!
     end
 
-    # ----------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     # Container node builders
-    # ----------------------------------------------------------------------------
+    # --------------------------------------------------------------------------
 
     # Opens a block for grouping objects to be pretty printed.
     #
@@ -546,17 +546,17 @@ class PrettyPrint
         last_spaces = 0
       end
 
-      next_queue.each do |part|
-        case part
+      next_queue.each do |next_part|
+        case next_part
         when IndentPart
           flush_spaces.call
           add_spaces.call(2)
         when StringAlignPart
           flush_spaces.call
-          next_value += part.n
-          next_length += part.n.length
+          next_value += next_part.n
+          next_length += next_part.n.length
         when NumberAlignPart
-          last_spaces += part.n
+          last_spaces += next_part.n
         end
       end
 
@@ -783,12 +783,12 @@ class PrettyPrint
         else
           should_remeasure = false
           next_cmd = [indent, MODE_FLAT, doc.contents]
-
-          if !doc.break? && fits?(next_cmd, commands, maxwidth - position)
-            commands << next_cmd
-          else
-            commands << [indent, MODE_BREAK, doc.contents]
-          end
+          commands <<
+            if !doc.break? && fits?(next_cmd, commands, maxwidth - position)
+              next_cmd
+            else
+              [indent, MODE_BREAK, doc.contents]
+            end
         end
       when IfBreak
         if mode == MODE_BREAK && doc.break_contents.any?
@@ -1060,7 +1060,7 @@ class PrettyPrint
   def text(object = "", width = object.length)
     doc = target.last
 
-    unless Text === doc
+    unless doc.is_a?(Text)
       doc = Text.new
       target << doc
     end

--- a/lib/syntax_tree/prettyprint.rb
+++ b/lib/syntax_tree/prettyprint.rb
@@ -375,7 +375,7 @@ class PrettyPrint
     #                This argument is a noop.
     # * +newline+ - Argument position expected to be here for compatibility.
     #               This argument is a noop.
-    def initialize(output, maxwidth = nil, newline = nil)
+    def initialize(output, _maxwidth = nil, _newline = nil)
       @output = Buffer.for(output)
       @target = @output
       @line_suffixes = Buffer::ArrayBuffer.new
@@ -397,7 +397,7 @@ class PrettyPrint
     # They are all noop arguments.
     def breakable(
       separator = " ",
-      width = separator.length,
+      _width = separator.length,
       indent: nil,
       force: nil
     )
@@ -410,7 +410,7 @@ class PrettyPrint
 
     # Appends +separator+ to the output buffer. +width+ is a noop here for
     # compatibility.
-    def fill_breakable(separator = " ", width = separator.length)
+    def fill_breakable(separator = " ", _width = separator.length)
       target << separator
     end
 
@@ -432,11 +432,11 @@ class PrettyPrint
     # * +open_width+ - noop argument. Present for compatibility.
     # * +close_width+ - noop argument. Present for compatibility.
     def group(
-      indent = nil,
+      _indent = nil,
       open_object = "",
       close_object = "",
-      open_width = nil,
-      close_width = nil
+      _open_width = nil,
+      _close_width = nil
     )
       target << open_object
       yield
@@ -478,14 +478,14 @@ class PrettyPrint
     # Takes +indent+ arg, but does nothing with it.
     #
     # Yields to a block.
-    def nest(indent)
+    def nest(_indent)
       yield
     end
 
     # Add +object+ to the text to be output.
     #
     # +width+ argument is here for compatibility. It is a noop argument.
-    def text(object = "", width = nil)
+    def text(object = "", _width = nil)
       target << object
     end
   end
@@ -623,9 +623,9 @@ class PrettyPrint
   #
   def self.singleline_format(
     output = "".dup,
-    maxwidth = nil,
-    newline = nil,
-    genspace = nil
+    _maxwidth = nil,
+    _newline = nil,
+    _genspace = nil
   )
     q = SingleLine.new(output)
     yield q

--- a/lib/syntax_tree/prettyprint.rb
+++ b/lib/syntax_tree/prettyprint.rb
@@ -778,17 +778,20 @@ class PrettyPrint
         position -= buffer.trim!
       when Group
         if mode == MODE_FLAT && !should_remeasure
-          commands <<
-            [indent, doc.break? ? MODE_BREAK : MODE_FLAT, doc.contents]
+          commands << [
+            indent,
+            doc.break? ? MODE_BREAK : MODE_FLAT,
+            doc.contents
+          ]
         else
           should_remeasure = false
           next_cmd = [indent, MODE_FLAT, doc.contents]
-          commands <<
-            if !doc.break? && fits?(next_cmd, commands, maxwidth - position)
-              next_cmd
-            else
-              [indent, MODE_BREAK, doc.contents]
-            end
+          commands << if !doc.break? &&
+               fits?(next_cmd, commands, maxwidth - position)
+            next_cmd
+          else
+            [indent, MODE_BREAK, doc.contents]
+          end
         end
       when IfBreak
         if mode == MODE_BREAK && doc.break_contents.any?

--- a/lib/syntax_tree/visitor.rb
+++ b/lib/syntax_tree/visitor.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module SyntaxTree
+  # Visitor is a parent class that provides the ability to walk down the tree
+  # and handle a subset of nodes. By defining your own subclass, you can
+  # explicitly handle a node type by defining a visit_* method.
   class Visitor
     # This is raised when you use the Visitor.visit_method method and it fails.
     # It is correctable to through DidYouMean.

--- a/lib/syntax_tree/visitor.rb
+++ b/lib/syntax_tree/visitor.rb
@@ -24,7 +24,9 @@ module SyntaxTree
 
       def corrections
         @corrections ||=
-          DidYouMean::SpellChecker.new(dictionary: Visitor.visit_methods).correct(visit_method)
+          DidYouMean::SpellChecker.new(
+            dictionary: Visitor.visit_methods
+          ).correct(visit_method)
       end
 
       DidYouMean.correct_error(VisitMethodError, self)

--- a/lib/syntax_tree/visitor/field_visitor.rb
+++ b/lib/syntax_tree/visitor/field_visitor.rb
@@ -220,9 +220,7 @@ module SyntaxTree
       end
 
       def visit_comma(node)
-        node(node, "comma") do
-          field("value", node)
-        end
+        node(node, "comma") { field("value", node) }
       end
 
       def visit_command(node)
@@ -244,9 +242,7 @@ module SyntaxTree
       end
 
       def visit_comment(node)
-        node(node, "comment") do
-          field("value", node.value)
-        end
+        node(node, "comment") { field("value", node.value) }
       end
 
       def visit_const(node)
@@ -376,27 +372,19 @@ module SyntaxTree
       end
 
       def visit_embdoc(node)
-        node(node, "embdoc") do
-          field("value", node.value)
-        end
+        node(node, "embdoc") { field("value", node.value) }
       end
 
       def visit_embexpr_beg(node)
-        node(node, "embexpr_beg") do
-          field("value", node.value)
-        end
+        node(node, "embexpr_beg") { field("value", node.value) }
       end
 
       def visit_embexpr_end(node)
-        node(node, "embexpr_end") do
-          field("value", node.value)
-        end
+        node(node, "embexpr_end") { field("value", node.value) }
       end
 
       def visit_embvar(node)
-        node(node, "embvar") do
-          field("value", node.value)
-        end
+        node(node, "embvar") { field("value", node.value) }
       end
 
       def visit_ensure(node)
@@ -548,9 +536,7 @@ module SyntaxTree
       end
 
       def visit_label_end(node)
-        node(node, "label_end") do
-          field("value", node.value)
-        end
+        node(node, "label_end") { field("value", node.value) }
       end
 
       def visit_lambda(node)
@@ -698,9 +684,7 @@ module SyntaxTree
       end
 
       def visit_qsymbols_beg(node)
-        node(node, "qsymbols_beg") do
-          field("value", node.value)
-        end
+        node(node, "qsymbols_beg") { field("value", node.value) }
       end
 
       def visit_qwords(node)
@@ -711,9 +695,7 @@ module SyntaxTree
       end
 
       def visit_qwords_beg(node)
-        node(node, "qwords_beg") do
-          field("value", node.value)
-        end
+        node(node, "qwords_beg") { field("value", node.value) }
       end
 
       def visit_rassign(node)
@@ -730,15 +712,11 @@ module SyntaxTree
       end
 
       def visit_rbrace(node)
-        node(node, "rbrace") do
-          field("value", node.value)
-        end
+        node(node, "rbrace") { field("value", node.value) }
       end
 
       def visit_rbracket(node)
-        node(node, "rbracket") do
-          field("value", node.value)
-        end
+        node(node, "rbracket") { field("value", node.value) }
       end
 
       def visit_redo(node)
@@ -746,21 +724,15 @@ module SyntaxTree
       end
 
       def visit_regexp_beg(node)
-        node(node, "regexp_beg") do
-          field("value", node.value)
-        end
+        node(node, "regexp_beg") { field("value", node.value) }
       end
 
       def visit_regexp_content(node)
-        node(node, "regexp_content") do
-          list("parts", node.parts)
-        end
+        node(node, "regexp_content") { list("parts", node.parts) }
       end
 
       def visit_regexp_end(node)
-        node(node, "regexp_end") do
-          field("value", node.value)
-        end
+        node(node, "regexp_end") { field("value", node.value) }
       end
 
       def visit_regexp_literal(node)
@@ -818,9 +790,7 @@ module SyntaxTree
       end
 
       def visit_rparen(node)
-        node(node, "rparen") do
-          field("value", node.value)
-        end
+        node(node, "rparen") { field("value", node.value) }
       end
 
       def visit_sclass(node)
@@ -847,9 +817,7 @@ module SyntaxTree
       end
 
       def visit_string_content(node)
-        node(node, "string_content") do
-          list("parts", node.parts)
-        end
+        node(node, "string_content") { list("parts", node.parts) }
       end
 
       def visit_string_dvar(node)
@@ -881,15 +849,11 @@ module SyntaxTree
       end
 
       def visit_symbeg(node)
-        node(node, "symbeg") do
-          field("value", node.value)
-        end
+        node(node, "symbeg") { field("value", node.value) }
       end
 
       def visit_symbol_content(node)
-        node(node, "symbol_content") do
-          field("value", node.value)
-        end
+        node(node, "symbol_content") { field("value", node.value) }
       end
 
       def visit_symbol_literal(node)
@@ -907,21 +871,15 @@ module SyntaxTree
       end
 
       def visit_symbols_beg(node)
-        node(node, "symbols_beg") do
-          field("value", node.value)
-        end
+        node(node, "symbols_beg") { field("value", node.value) }
       end
 
       def visit_tlambda(node)
-        node(node, "tlambda") do
-          field("value", node.value)
-        end
+        node(node, "tlambda") { field("value", node.value) }
       end
 
       def visit_tlambeg(node)
-        node(node, "tlambeg") do
-          field("value", node.value)
-        end
+        node(node, "tlambeg") { field("value", node.value) }
       end
 
       def visit_top_const_field(node)
@@ -939,9 +897,7 @@ module SyntaxTree
       end
 
       def visit_tstring_beg(node)
-        node(node, "tstring_beg") do
-          field("value", node.value)
-        end
+        node(node, "tstring_beg") { field("value", node.value) }
       end
 
       def visit_tstring_content(node)
@@ -949,9 +905,7 @@ module SyntaxTree
       end
 
       def visit_tstring_end(node)
-        node(node, "tstring_end") do
-          field("value", node.value)
-        end
+        node(node, "tstring_end") { field("value", node.value) }
       end
 
       def visit_unary(node)
@@ -1032,9 +986,7 @@ module SyntaxTree
       end
 
       def visit_void_stmt(node)
-        node(node, "void_stmt") do
-          comments(node)
-        end
+        node(node, "void_stmt") { comments(node) }
       end
 
       def visit_when(node)
@@ -1077,15 +1029,11 @@ module SyntaxTree
       end
 
       def visit_words_beg(node)
-        node(node, "words_beg") do
-          field("value", node.value)
-        end
+        node(node, "words_beg") { field("value", node.value) }
       end
 
       def visit_xstring(node)
-        node(node, "xstring") do
-          list("parts", node.parts)
-        end
+        node(node, "xstring") { list("parts", node.parts) }
       end
 
       def visit_xstring_literal(node)

--- a/lib/syntax_tree/visitor/json_visitor.rb
+++ b/lib/syntax_tree/visitor/json_visitor.rb
@@ -1,4 +1,4 @@
-  # frozen_string_literal: true
+# frozen_string_literal: true
 
 module SyntaxTree
   class Visitor

--- a/lib/syntax_tree/visitor/match_visitor.rb
+++ b/lib/syntax_tree/visitor/match_visitor.rb
@@ -56,7 +56,7 @@ module SyntaxTree
         end
       end
 
-      def node(node, type)
+      def node(node, _type)
         items = []
         q.with_target(items) { yield }
 

--- a/lib/syntax_tree/visitor/pretty_print_visitor.rb
+++ b/lib/syntax_tree/visitor/pretty_print_visitor.rb
@@ -47,7 +47,7 @@ module SyntaxTree
         end
       end
 
-      def node(node, type)
+      def node(_node, type)
         q.group(2, "(", ")") do
           q.text(type)
           yield

--- a/lib/syntax_tree/visitor/pretty_print_visitor.rb
+++ b/lib/syntax_tree/visitor/pretty_print_visitor.rb
@@ -1,4 +1,4 @@
-  # frozen_string_literal: true
+# frozen_string_literal: true
 
 module SyntaxTree
   class Visitor

--- a/syntax_tree.gemspec
+++ b/syntax_tree.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
     end
   end
 
+  spec.required_ruby_version = ">= 2.7.3"
+
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]

--- a/syntax_tree.gemspec
+++ b/syntax_tree.gemspec
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 
-require_relative 'lib/syntax_tree/version'
+require_relative "lib/syntax_tree/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'syntax_tree'
-  spec.version       = SyntaxTree::VERSION
-  spec.authors       = ['Kevin Newton']
-  spec.email         = ['kddnewton@gmail.com']
+  spec.name = "syntax_tree"
+  spec.version = SyntaxTree::VERSION
+  spec.authors = ["Kevin Newton"]
+  spec.email = ["kddnewton@gmail.com"]
 
-  spec.summary       = 'A parser based on ripper'
-  spec.homepage      = 'https://github.com/kddnewton/syntax_tree'
-  spec.license       = 'MIT'
-  spec.metadata      = { 'rubygems_mfa_required' => 'true' }
+  spec.summary = "A parser based on ripper"
+  spec.homepage = "https://github.com/kddnewton/syntax_tree"
+  spec.license = "MIT"
+  spec.metadata = { "rubygems_mfa_required" => "true" }
 
-  spec.files         = Dir.chdir(__dir__) do
-    `git ls-files -z`.split("\x0").reject do |f|
-      f.match(%r{^(test|spec|features)/})
+  spec.files =
+    Dir.chdir(__dir__) do
+      `git ls-files -z`.split("\x0")
+        .reject { |f| f.match(%r{^(test|spec|features)/}) }
     end
-  end
 
   spec.required_ruby_version = ">= 2.7.3"
 
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
-  spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'minitest'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "minitest"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "simplecov"
 end

--- a/test/fixtures/hshptn.rb
+++ b/test/fixtures/hshptn.rb
@@ -14,9 +14,17 @@ end
 case foo
 in bar:, baz:
 end
+-
+case foo
+in { bar:, baz: }
+end
 %
 case foo
 in bar: bar, baz: baz
+end
+-
+case foo
+in { bar: bar, baz: baz }
 end
 %
 case foo
@@ -24,8 +32,10 @@ in **bar
 end
 %
 case foo
-in foo:, # comment1
-   bar: # comment2
+in {
+     foo:, # comment1
+     bar: # comment2
+   }
   baz
 end
 %

--- a/test/formatting_test.rb
+++ b/test/formatting_test.rb
@@ -12,7 +12,10 @@ module SyntaxTree
 
     def test_format_class_level
       source = "1+1"
-      assert_equal("1 + 1\n", SyntaxTree::Formatter.format(source, SyntaxTree.parse(source)))
+      assert_equal(
+        "1 + 1\n",
+        SyntaxTree::Formatter.format(source, SyntaxTree.parse(source))
+      )
     end
   end
 end

--- a/test/idempotency_test.rb
+++ b/test/idempotency_test.rb
@@ -10,7 +10,11 @@ module SyntaxTree
         source = SyntaxTree.read(filepath)
         formatted = SyntaxTree.format(source)
 
-        assert_equal(formatted, SyntaxTree.format(formatted), "expected #{filepath} to be formatted idempotently")
+        assert_equal(
+          formatted,
+          SyntaxTree.format(formatted),
+          "expected #{filepath} to be formatted idempotently"
+        )
       end
     end
   end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -9,7 +9,8 @@ module SyntaxTree
       events = Ripper::EVENTS
 
       # Next, subtract all of the events that we have explicitly defined.
-      events -= Parser.private_instance_methods(false).grep(/^on_(\w+)/) { $1.to_sym }
+      events -=
+        Parser.private_instance_methods(false).grep(/^on_(\w+)/) { $1.to_sym }
 
       # Next, subtract the list of events that we purposefully skipped.
       events -= %i[

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,12 +22,12 @@ module Fixtures
     fndptn
     rassign
     rassign_rocket
-  ]
+  ].freeze
 
   FIXTURES_3_1_0 = %w[
     pinned_begin
     var_field_rassign
-  ]
+  ].freeze
 
   Fixture = Struct.new(:name, :source, :formatted, keyword_init: true)
 
@@ -57,9 +57,7 @@ module Fixtures
         # If there's a comment starting with >= that starts after the % that
         # delineates the test, then we're going to check if the version
         # satisfies that constraint.
-        if comment&.start_with?(">=")
-          next if ruby_version < Gem::Version.new(comment.split[1])
-        end
+        next if comment&.start_with?(">=") && (ruby_version < Gem::Version.new(comment.split[1]))
 
         name = :"#{fixture}_#{index}"
         yield Fixture.new(name: name, source: source, formatted: formatted || source)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,10 +24,7 @@ module Fixtures
     rassign_rocket
   ].freeze
 
-  FIXTURES_3_1_0 = %w[
-    pinned_begin
-    var_field_rassign
-  ].freeze
+  FIXTURES_3_1_0 = %w[pinned_begin var_field_rassign].freeze
 
   Fixture = Struct.new(:name, :source, :formatted, keyword_init: true)
 
@@ -50,18 +47,30 @@ module Fixtures
       filepath = File.expand_path("fixtures/#{fixture}.rb", __dir__)
 
       # For each fixture in the fixture file yield a Fixture object.
-      File.readlines(filepath).slice_before(delimiter).each_with_index do |source, index|
-        comment = source.shift.match(delimiter)[1]
-        source, formatted = source.join.split("-\n")
+      File
+        .readlines(filepath)
+        .slice_before(delimiter)
+        .each_with_index do |source, index|
+          comment = source.shift.match(delimiter)[1]
+          source, formatted = source.join.split("-\n")
 
-        # If there's a comment starting with >= that starts after the % that
-        # delineates the test, then we're going to check if the version
-        # satisfies that constraint.
-        next if comment&.start_with?(">=") && (ruby_version < Gem::Version.new(comment.split[1]))
+          # If there's a comment starting with >= that starts after the % that
+          # delineates the test, then we're going to check if the version
+          # satisfies that constraint.
+          if comment&.start_with?(">=") &&
+               (ruby_version < Gem::Version.new(comment.split[1]))
+            next
+          end
 
-        name = :"#{fixture}_#{index}"
-        yield Fixture.new(name: name, source: source, formatted: formatted || source)
-      end
+          name = :"#{fixture}_#{index}"
+          yield(
+            Fixture.new(
+              name: name,
+              source: source,
+              formatted: formatted || source
+            )
+          )
+        end
     end
   end
 end

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -12,9 +12,9 @@ class VisitorTest < Minitest::Test
 
       program.statements.body.last.bodystmt.statements.body.each do |node|
         case node
-        in SyntaxTree::ClassDeclaration[superclass: {
-             value: { value: "Node" }
-           }]
+        in SyntaxTree::ClassDeclaration[
+             superclass: { value: { value: "Node" } }
+           ]
           # this is a class we want to look at
         else
           next
@@ -31,11 +31,9 @@ class VisitorTest < Minitest::Test
           end
 
         case accept
-        in {
-             bodystmt: {
-               statements: {
-                 body: [SyntaxTree::Call[message: { value: visit_method }]]
-               }
+        in bodystmt: {
+             statements: {
+               body: [SyntaxTree::Call[message: { value: visit_method }]]
              }
            }
           assert_respond_to(visitor, visit_method)

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -12,7 +12,9 @@ class VisitorTest < Minitest::Test
 
       program.statements.body.last.bodystmt.statements.body.each do |node|
         case node
-        in SyntaxTree::ClassDeclaration[superclass: { value: { value: "Node" } }]
+        in SyntaxTree::ClassDeclaration[superclass: {
+             value: { value: "Node" }
+           }]
           # this is a class we want to look at
         else
           next
@@ -29,7 +31,13 @@ class VisitorTest < Minitest::Test
           end
 
         case accept
-        in { bodystmt: { statements: { body: [SyntaxTree::Call[message: { value: visit_method }]] } } }
+        in {
+             bodystmt: {
+               statements: {
+                 body: [SyntaxTree::Call[message: { value: visit_method }]]
+               }
+             }
+           }
           assert_respond_to(visitor, visit_method)
         end
       end
@@ -51,7 +59,7 @@ class VisitorTest < Minitest::Test
 
     visitor = DummyVisitor.new
     visitor.visit(parsed_tree)
-    assert_equal(["Foo", "foo", "Bar", "bar", "baz"], visitor.visited_nodes)
+    assert_equal(%w[Foo foo Bar bar baz], visitor.visited_nodes)
   end
 
   class DummyVisitor < SyntaxTree::Visitor


### PR DESCRIPTION
* Add a rubocop config that we can ship with the gem so folks can inherit from it to get their styling correct.
* Inherit from it ourselves and fix all of the existing style violations.
* Improve hash pattern formatting by a lot - multiple lines are now not so ugly.
* Add a CI check for syntax tree formatting and rubocop linting.