### PR TITLE
Options on regexp

### DIFF
--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -7456,6 +7456,7 @@ module SyntaxTree
       {
         beginning: beginning,
         ending: ending,
+        options: options,
         parts: parts,
         location: location,
         comments: comments
@@ -7490,16 +7491,20 @@ module SyntaxTree
           end
 
           q.text("}")
-          q.text(ending[1..])
+          q.text(options)
         end
       else
         q.group do
           q.text("/")
           q.format_each(parts)
           q.text("/")
-          q.text(ending[1..])
+          q.text(options)
         end
       end
+    end
+
+    def options
+      ending[1..]
     end
 
     private

--- a/lib/syntax_tree/visitor/field_visitor.rb
+++ b/lib/syntax_tree/visitor/field_visitor.rb
@@ -738,6 +738,7 @@ module SyntaxTree
       def visit_regexp_literal(node)
         node(node, "regexp_literal") do
           list("parts", node.parts)
+          field("options", node.options)
           comments(node)
         end
       end


### PR DESCRIPTION
Add `options` as a method on `SyntaxTree::RegexpLiteral`, add it to pattern matching, and describe it using the `SyntaxTree::Visitor::FieldVisitor` class.

Closes #62