### PR TITLE
Disallow turning a conditional into a ternary if there's a Not node without parentheses in the predicate

### DIFF
--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -5192,7 +5192,7 @@ module SyntaxTree
         else
           # Otherwise, we're going to check the conditional for certain cases.
           case node
-          in predicate: Assign | Command | CommandCall | MAssign | OpAssign
+          in predicate: Assign | Command | CommandCall | MAssign | Not | OpAssign
             false
           in {
                statements: { body: [truthy] },

--- a/test/fixtures/if.rb
+++ b/test/fixtures/if.rb
@@ -35,3 +35,9 @@ end
 %
 if foo {}
 end
+%
+if not a
+  b
+else
+  c
+end


### PR DESCRIPTION
fixes https://github.com/ruby-syntax-tree/syntax_tree/issues/58
