### PR TITLE
Introduce new node `SyntaxTree::HeredocEnd`

### DIFF
--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -4813,7 +4813,7 @@ module SyntaxTree
     # [HeredocBeg] the opening of the heredoc
     attr_reader :beginning
 
-    # [String] the ending of the heredoc
+    # [HeredocEnd] the ending of the heredoc
     attr_reader :ending
 
     # [Integer] how far to dedent the heredoc
@@ -4847,7 +4847,7 @@ module SyntaxTree
     end
 
     def child_nodes
-      [beginning, *parts]
+      [beginning, *parts, ending]
     end
 
     alias deconstruct child_nodes
@@ -4883,7 +4883,7 @@ module SyntaxTree
               end
             end
 
-            q.text(ending)
+            q.format(ending)
           end
         end
       end
@@ -4912,6 +4912,45 @@ module SyntaxTree
 
     def accept(visitor)
       visitor.visit_heredoc_beg(self)
+    end
+
+    def child_nodes
+      []
+    end
+
+    alias deconstruct child_nodes
+
+    def deconstruct_keys(_keys)
+      { value: value, location: location, comments: comments }
+    end
+
+    def format(q)
+      q.text(value)
+    end
+  end
+
+  # HeredocEnd represents the closing declaration of a heredoc.
+  #
+  #     <<~DOC
+  #       contents
+  #     DOC
+  #
+  # In the example above the HeredocEnd node represents the closing DOC.
+  class HeredocEnd < Node
+    # [String] the closing declaration of the heredoc
+    attr_reader :value
+
+    # [Array[ Comment | EmbDoc ]] the comments attached to this node
+    attr_reader :comments
+
+    def initialize(value:, location:, comments: [])
+      @value = value
+      @location = location
+      @comments = comments
+    end
+
+    def accept(visitor)
+      visitor.visit_heredoc_end(self)
     end
 
     def child_nodes

--- a/lib/syntax_tree/parser.rb
+++ b/lib/syntax_tree/parser.rb
@@ -1640,9 +1640,19 @@ module SyntaxTree
     def on_heredoc_end(value)
       heredoc = @heredocs[-1]
 
+      location =
+      Location.token(
+        line: lineno,
+        char: char_pos,
+        column: current_column,
+        size: value.size + 1
+      )
+
+      heredoc_end = HeredocEnd.new(value: value.chomp, location: location)
+
       @heredocs[-1] = Heredoc.new(
         beginning: heredoc.beginning,
-        ending: value.chomp,
+        ending: heredoc_end,
         dedent: heredoc.dedent,
         parts: heredoc.parts,
         location:

--- a/lib/syntax_tree/visitor.rb
+++ b/lib/syntax_tree/visitor.rb
@@ -194,6 +194,9 @@ module SyntaxTree
     # Visit a HeredocBeg node.
     alias visit_heredoc_beg visit_child_nodes
 
+    # Visit a HeredocEnd node.
+    alias visit_heredoc_end visit_child_nodes
+
     # Visit a HshPtn node.
     alias visit_hshptn visit_child_nodes
 

--- a/lib/syntax_tree/visitor/field_visitor.rb
+++ b/lib/syntax_tree/visitor/field_visitor.rb
@@ -497,6 +497,10 @@ module SyntaxTree
         visit_token(node, "heredoc_beg")
       end
 
+      def visit_heredoc_end(node)
+        visit_token(node, "heredoc_end")
+      end
+
       def visit_hshptn(node)
         node(node, "hshptn") do
           field("constant", node.constant) if node.constant

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -546,6 +546,17 @@ module SyntaxTree
       assert_node(HeredocBeg, source, at: at, &:beginning)
     end
 
+    def test_heredoc_end
+      source = <<~SOURCE
+        <<~HEREDOC
+          contents
+        HEREDOC
+      SOURCE
+
+      at = location(lines: 3..3, chars: 22..31, columns: 0..9)
+      assert_node(HeredocEnd, source, at: at, &:ending)
+    end
+
     def test_hshptn
       source = <<~SOURCE
         case value


### PR DESCRIPTION
# Why
As I mentioned on Slack, currently we only have access to `SyntaxTree::HeredocBeg` which only gives us the opening HEREDOC delimiter. The closing delimiter is only provided as a String in `SyntaxTree::Heredoc`. Having a `SyntaxTree::HeredocEnd` node for the closing delimiter's location would be helpful. 

Then, we won't have to do the calculations ourselves and seems more consistent with the existence of `HeredocBeg`.  

# Changes

I followed the way `HeredocBeg` was implemented and added tests. 