### PR TITLE
Fix up did_you_mean usage

### DIFF
--- a/lib/syntax_tree/basic_visitor.rb
+++ b/lib/syntax_tree/basic_visitor.rb
@@ -33,7 +33,11 @@ module SyntaxTree
           ).correct(visit_method)
       end
 
-      DidYouMean.correct_error(VisitMethodError, self)
+      # In some setups with Ruby you can turn off DidYouMean, so we're going to
+      # respect that setting here.
+      if defined?(DidYouMean) && DidYouMean.method_defined?(:correct_error)
+        DidYouMean.correct_error(VisitMethodError, self)
+      end
     end
 
     class << self

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -40,9 +40,18 @@ module SyntaxTree
       end
     end
 
-    def test_visit_method_correction
-      error = assert_raises { Visitor.visit_method(:visit_binar) }
-      assert_match(/visit_binary/, error.message)
+    if defined?(DidYouMean) && DidYouMean.method_defined?(:correct_error)
+      def test_visit_method_correction
+        error = assert_raises { Visitor.visit_method(:visit_binar) }
+        message =
+          if Exception.method_defined?(:detailed_message)
+            error.detailed_message
+          else
+            error.message
+          end
+
+        assert_match(/visit_binary/, message)
+      end
     end
   end
 end


### PR DESCRIPTION
did_you_mean now checks `Exception.method_defined?(:detailed_message)` to determine which method to override per https://github.com/ruby/did_you_mean/commit/62799d728c351ff10ecf84f04611d95a1cbf104a. This breaks our tests because previously we were checking `error.message` to assert that the error had been corrected, but now we need to check `error.detailed_message`. We need to switch here in the same way they do to support older versions of did_you_mean as well.