### PR TITLE
Allow CLI flags for lsp

### DIFF
--- a/lib/syntax_tree/cli.rb
+++ b/lib/syntax_tree/cli.rb
@@ -218,7 +218,7 @@ module SyntaxTree
       #{Color.bold("stree help")}
         Display this help message
 
-      #{Color.bold("stree lsp")}
+      #{Color.bold("stree lsp [OPTIONS]")}
         Run syntax tree in language server mode
 
       #{Color.bold("stree version")}
@@ -238,6 +238,20 @@ module SyntaxTree
       # passed to the invocation.
       def run(argv)
         name, *arguments = argv
+
+        # If there are any plugins specified on the command line, then load them
+        # by requiring them here. We do this by transforming something like
+        #
+        #     stree format --plugins=haml template.haml
+        #
+        # into
+        #
+        #     require "syntax_tree/haml"
+        #
+        if arguments.first&.start_with?("--plugins=")
+          plugins = arguments.shift[/^--plugins=(.*)$/, 1]
+          plugins.split(",").each { |plugin| require "syntax_tree/#{plugin}" }
+        end
 
         case name
         when "help"
@@ -280,20 +294,6 @@ module SyntaxTree
         if $stdin.tty? && arguments.empty?
           warn(HELP)
           return 1
-        end
-
-        # If there are any plugins specified on the command line, then load them
-        # by requiring them here. We do this by transforming something like
-        #
-        #     stree format --plugins=haml template.haml
-        #
-        # into
-        #
-        #     require "syntax_tree/haml"
-        #
-        if arguments.first&.start_with?("--plugins=")
-          plugins = arguments.shift[/^--plugins=(.*)$/, 1]
-          plugins.split(",").each { |plugin| require "syntax_tree/#{plugin}" }
         end
 
         # We're going to build up a queue of items to process.

--- a/lib/syntax_tree/language_server.rb
+++ b/lib/syntax_tree/language_server.rb
@@ -36,8 +36,9 @@ module SyntaxTree
           write(id: id, result: { capabilities: capabilities })
         in method: "initialized"
           # ignored
-        in method: "shutdown"
+        in method: "shutdown" # tolerate missing ID to be a good citizen
           store.clear
+          write(id: request[:id], result: {})
           return
         in {
              method: "textDocument/didChange",


### PR DESCRIPTION
This lets me invoke the language server with plugins registered, to ensure that formatting works the way I want it to in my project. Rebased on top of #100 so that I could test them in concert. Works like a charm with `vscode-syntax-tree`!

P.S. this PR could stand to have a test added to make sure LSP always parses opts. LMK if the approach is sound and I'll whip up a test.