### PR TITLE
Respond to LSP Shutdown command to prevent VS Code deadlocks

### DIFF
--- a/lib/syntax_tree/language_server.rb
+++ b/lib/syntax_tree/language_server.rb
@@ -36,8 +36,9 @@ module SyntaxTree
           write(id: id, result: { capabilities: capabilities })
         in method: "initialized"
           # ignored
-        in method: "shutdown"
+        in method: "shutdown" # tolerate missing ID to be a good citizen
           store.clear
+          write(id: request[:id], result: {})
           return
         in {
              method: "textDocument/didChange",


### PR DESCRIPTION
While evaluating the `ruby-syntax-tree` extension I found that restarting the language server doesn't work: the JSON RPC call never resolves in the language-server client code, therefore the `await` never gets fulfilled.

Inspection of VS Code's JSON RPC stack revealed that _every_ RPC expects a response. So, I added a response to stree's LSP and verified this makes VS Code happy. With this fix in place, the restart command works!