### PR TITLE
Add inlay hint support per LSP specification.

### DIFF
--- a/test/language_server/inlay_hints_test.rb
+++ b/test/language_server/inlay_hints_test.rb
@@ -11,6 +11,7 @@ module SyntaxTree
 
         assert_equal(1, hints.before.length)
         assert_equal(1, hints.after.length)
+        assert_equal(2, hints.all.length)
       end
 
       def test_operators_in_binaries
@@ -18,6 +19,7 @@ module SyntaxTree
 
         assert_equal(1, hints.before.length)
         assert_equal(1, hints.after.length)
+        assert_equal(2, hints.all.length)
       end
 
       def test_binaries_in_assignments
@@ -25,6 +27,7 @@ module SyntaxTree
 
         assert_equal(1, hints.before.length)
         assert_equal(1, hints.after.length)
+        assert_equal(2, hints.all.length)
       end
 
       def test_nested_ternaries
@@ -32,12 +35,14 @@ module SyntaxTree
 
         assert_equal(1, hints.before.length)
         assert_equal(1, hints.after.length)
+        assert_equal(2, hints.all.length)
       end
 
       def test_bare_rescue
         hints = find("begin; rescue; end")
 
         assert_equal(1, hints.after.length)
+        assert_equal(1, hints.all.length)
       end
 
       def test_unary_in_binary
@@ -45,6 +50,7 @@ module SyntaxTree
 
         assert_equal(1, hints.before.length)
         assert_equal(1, hints.after.length)
+        assert_equal(2, hints.all.length)
       end
 
       private


### PR DESCRIPTION
Closes #103.

I'm retaining the support for the old-style RPC for now to avoid breaking the VS Code extension. I guess we'd technically increment the minor version of `syntax_tree`, release a new cut of the extension, and then increment the `major` version of `syntax_tree` when removing support for the proprietary stuff! What a pain.

It begs the question: should the LSP server be built into the `syntax_tree` gem, if it's likely to change frequently? I suppose that depends on the future of the parsing and formatting functions -- if some or all of the gem will be accepted as a built-in gem, then perhaps that would be a good time to split it up.