### PR TITLE
Add print_width config option for rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,16 @@ SyntaxTree::Rake::WriteTask.new do |t|
 end
 ```
 
+#### `print_width`
+
+If you want to use a different print width from the default (80), you can pass that to the `print_width` field, as in:
+
+```ruby
+SyntaxTree::Rake::WriteTask.new do |t|
+  t.print_width = 100
+end
+```
+
 #### `plugins`
 
 If you're running Syntax Tree with plugins (either your own or the pre-built ones), you can pass that to the `plugins` field, as in:

--- a/lib/syntax_tree/rake/check_task.rb
+++ b/lib/syntax_tree/rake/check_task.rb
@@ -35,14 +35,20 @@ module SyntaxTree
       # Defaults to [].
       attr_accessor :plugins
 
+      # Max line length.
+      # Defaults to 80.
+      attr_accessor :print_width
+
       def initialize(
         name = :"stree:check",
         source_files = ::Rake::FileList["lib/**/*.rb"],
-        plugins = []
+        plugins = [],
+        print_width = DEFAULT_PRINT_WIDTH
       )
         @name = name
         @source_files = source_files
         @plugins = plugins
+        @print_width = print_width
 
         yield self if block_given?
         define_task
@@ -58,6 +64,7 @@ module SyntaxTree
       def run_task
         arguments = ["check"]
         arguments << "--plugins=#{plugins.join(",")}" if plugins.any?
+        arguments << "--print-width=#{print_width}" if print_width != DEFAULT_PRINT_WIDTH
 
         SyntaxTree::CLI.run(arguments + Array(source_files))
       end

--- a/lib/syntax_tree/rake/write_task.rb
+++ b/lib/syntax_tree/rake/write_task.rb
@@ -35,14 +35,20 @@ module SyntaxTree
       # Defaults to [].
       attr_accessor :plugins
 
+      # Max line length.
+      # Defaults to 80.
+      attr_accessor :print_width
+
       def initialize(
         name = :"stree:write",
         source_files = ::Rake::FileList["lib/**/*.rb"],
-        plugins = []
+        plugins = [],
+        print_width = DEFAULT_PRINT_WIDTH
       )
         @name = name
         @source_files = source_files
         @plugins = plugins
+        @print_width = print_width
 
         yield self if block_given?
         define_task
@@ -58,6 +64,7 @@ module SyntaxTree
       def run_task
         arguments = ["write"]
         arguments << "--plugins=#{plugins.join(",")}" if plugins.any?
+        arguments << "--print-width=#{print_width}" if print_width != DEFAULT_PRINT_WIDTH
 
         SyntaxTree::CLI.run(arguments + Array(source_files))
       end


### PR DESCRIPTION
These rake task helpers are super handy, but they don't allow configuring the `--print-width` option.  This adds the option to both `WriteTask` and `CheckTask`, making it available in just the same way as the other options.

The existing tests for this rake task don't exercise most of the other options, so I didn't add any new tests here, especially since the logic is minimal. I have tested this locally, and it's working exactly as expected. I'm also happy to add more automated tests if you'd like.