### PR TITLE
Add support for a simple config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It is built with only standard library dependencies. It additionally ships with 
   - [json](#json)
   - [match](#match)
   - [write](#write)
+  - [Configuration](#configuration)
 - [Library](#library)
   - [SyntaxTree.read(filepath)](#syntaxtreereadfilepath)
   - [SyntaxTree.parse(source)](#syntaxtreeparsesource)
@@ -230,6 +231,19 @@ To change the print width that you are writing with, specify the `--print-width`
 ```sh
 stree write --print-width=100 path/to/file.rb
 ```
+
+### Configuration
+
+Any of the above CLI commands can also read configuration options from a `.streerc` file in the directory where the commands are executed.
+
+This should be a text file with each argument on a separate line.
+
+```txt
+--print-width=100
+--plugins=plugin/trailing_comma
+```
+
+If this file is present, it will _always_ be used for CLI commands. You can also pass options from the command line as in the examples above. The options in the `.streerc` file are passed to the CLI first, then the arguments from the command line. In the case of exclusive options (e.g. `--print-width`), this means that the command line options override what's in the config file. In the case of options that can take multiple inputs (e.g. `--plugins`), the effect is additive. That is, the plugins passed from the command line will be loaded _in addition to_ the plugins in the config file.
 
 ## Library
 

--- a/lib/syntax_tree/cli.rb
+++ b/lib/syntax_tree/cli.rb
@@ -4,6 +4,8 @@ module SyntaxTree
   # Syntax Tree ships with the `stree` CLI, which can be used to inspect and
   # manipulate Ruby code. This module is responsible for powering that CLI.
   module CLI
+    CONFIG_FILE = ".streerc"
+
     # A utility wrapper around colored strings in the output.
     class Color
       attr_reader :value, :code
@@ -268,6 +270,11 @@ module SyntaxTree
       def run(argv)
         name, *arguments = argv
         print_width = DEFAULT_PRINT_WIDTH
+
+        config_file = File.join(Dir.pwd, CONFIG_FILE)
+        if File.readable?(config_file)
+          arguments.unshift(*File.readlines(config_file, chomp: true))
+        end
 
         while arguments.first&.start_with?("--")
           case (argument = arguments.shift)


### PR DESCRIPTION
Following on from conversation in #124, I'm taking a pass at what I think is a useful but fairly simple approach to supporting a config file. I'd love to hear any and all feedback on this.  I see this as a viable solution in particular but also as a means to have more concrete discussions about the topic generally.

### Context 
As syntax_tree gains wider usage, it'll be very helpful to allow projects to commit their particular configs within their repo for use by any tool that uses `stree` instead of having to create wrapper scripts, rely on rake tasks that come with their own overhead, or manually keep settings up to date among all contributors.

### Approach
This set of changes takes inspiration from [Sorbet](https://sorbet.org/docs/cli#config-file) to provide users with a simple config file that's also easy to parse and use within the gem. It's a text file that has the exact options you'd pass on the command line, each on their own line. These are parsed and prepended to the arguments array within `CLI.run`, still allowing for other options to passed from the command line.

### Limiting Scope (and Future Extensions)
I decided to restrict this only to the command line options and avoid the source files argument, opting to let other tools pass their own source file from the command line, which is preferable for tools like editor integrations that might interact with a single file at a time. If users want to interact with all of their Ruby files at once, the rake tasks are perfect for providing larger, static patterns of files. And since they use `CLI.run` as well, they'll pick up options from a `.syntax_tree` file, if present.

I also opted for only supporting a single .syntax_tree file at the project root. If there's a need for multiple configs or config locations, this can be easily extended to look up through a directory structure or accept an option for a specific config file location (or even a different filename). Those felt out of scope for this initial support.