### PR TITLE
docs: add information on neovim and vim editor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,9 +548,11 @@ inherit_gem:
   syntax_tree: config/rubocop.yml
 ```
 
-### VSCode
+### Editors
 
-To integrate Syntax Tree into VSCode, you should use the official VSCode extension [ruby-syntax-tree/vscode-syntax-tree](https://github.com/ruby-syntax-tree/vscode-syntax-tree).
+* Neovim - formatting via the LSP server can be configured using [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig).
+* Vim - format via the CLI using [ALE (Asynchronous Lint Engine)](https://github.com/dense-analysis/ale).
+* Visual Studio Code - use the official extension [ruby-syntax-tree/vscode-syntax-tree](https://github.com/ruby-syntax-tree/vscode-syntax-tree).
 
 ## Contributing
 


### PR DESCRIPTION
Official support for syntax tree in Neovim via the native LSP client (https://github.com/neovim/nvim-lspconfig/pull/2056) and Vim via the ALE plugin (https://github.com/dense-analysis/ale/pull/4268) has been added. We've been using them quite successfully for a few weeks.

If anyone needs help configuring, please feel free to ping me in a discussion thread.