### PR TITLE
Consume end tokens on begins with rescue or ensure

### DIFF
--- a/lib/syntax_tree/parser.rb
+++ b/lib/syntax_tree/parser.rb
@@ -717,8 +717,7 @@ module SyntaxTree
       else
         keyword = find_token(Kw, "begin")
         end_location =
-          if bodystmt.rescue_clause || bodystmt.ensure_clause ||
-               bodystmt.else_clause
+          if bodystmt.else_clause
             bodystmt.location
           else
             find_token(Kw, "end").location

--- a/test/fixtures/def_endless.rb
+++ b/test/fixtures/def_endless.rb
@@ -18,3 +18,11 @@ def self.foo() = bar
 def self.foo = bar
 % # >= 3.1.0
 def self.foo = bar baz
+%
+begin
+  true
+rescue StandardError
+  false
+end
+
+def foo? = true


### PR DESCRIPTION
Not consuming the end tokens for begins that include ensure/rescue will cause parsing endless method definitions immediately after to fail.