### PR TITLE
Use q.format for Formatter.format

### DIFF
--- a/lib/syntax_tree/formatter.rb
+++ b/lib/syntax_tree/formatter.rb
@@ -43,10 +43,10 @@ module SyntaxTree
     end
 
     def self.format(source, node)
-      formatter = new(source, [])
-      node.format(formatter)
-      formatter.flush
-      formatter.output.join
+      q = new(source, [])
+      q.format(node)
+      q.flush
+      q.output.join
     end
 
     def format(node, stackable: true)


### PR DESCRIPTION
When you're formatting an individual node, it's useful to push it
onto the parent stack to make sure every child node can format
properly.