### PR TITLE
Fix CLI checking for content

### DIFF
--- a/lib/syntax_tree/cli.rb
+++ b/lib/syntax_tree/cli.rb
@@ -423,19 +423,12 @@ module SyntaxTree
             return 1
           end
 
-        # If we're not reading from stdin and the user didn't supply any
-        # filepaths to be read, then we exit with the usage message.
-        if $stdin.tty? && arguments.empty? && options.scripts.empty?
-          warn(HELP)
-          return 1
-        end
-
         # We're going to build up a queue of items to process.
         queue = Queue.new
 
-        # If we're reading from stdin, then we'll just add the stdin object to
-        # the queue. Otherwise, we'll add each of the filepaths to the queue.
-        if $stdin.tty? && (arguments.any? || options.scripts.any?)
+        # If there are any arguments or scripts, then we'll add those to the
+        # queue. Otherwise we'll read the content off STDIN.
+        if arguments.any? || options.scripts.any?
           arguments.each do |pattern|
             Dir
               .glob(pattern)

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -123,13 +123,6 @@ module SyntaxTree
     end
 
     def test_no_arguments
-      with_tty do
-        *, stderr = capture_io { SyntaxTree::CLI.run(["check"]) }
-        assert_includes(stderr, "stree help")
-      end
-    end
-
-    def test_no_arguments_no_tty
       stdin = $stdin
       $stdin = StringIO.new("1+1")
 
@@ -140,17 +133,13 @@ module SyntaxTree
     end
 
     def test_inline_script
-      with_tty do
-        stdio, = capture_io { SyntaxTree::CLI.run(%w[format -e 1+1]) }
-        assert_equal("1 + 1\n", stdio)
-      end
+      stdio, = capture_io { SyntaxTree::CLI.run(%w[format -e 1+1]) }
+      assert_equal("1 + 1\n", stdio)
     end
 
     def test_multiple_inline_scripts
-      with_tty do
-        stdio, = capture_io { SyntaxTree::CLI.run(%w[format -e 1+1 -e 2+2]) }
-        assert_equal("1 + 1\n2 + 2\n", stdio)
-      end
+      stdio, = capture_io { SyntaxTree::CLI.run(%w[format -e 1+1 -e 2+2]) }
+      assert_equal("1 + 1\n2 + 2\n", stdio)
     end
 
     def test_generic_error
@@ -251,20 +240,14 @@ module SyntaxTree
 
       status = nil
       stdio, stderr =
-        with_tty do
-          capture_io do
-            status = SyntaxTree::CLI.run([command, *args, tempfile.path])
-          end
+        capture_io do
+          status = SyntaxTree::CLI.run([command, *args, tempfile.path])
         end
 
       Result.new(status: status, stdio: stdio, stderr: stderr)
     ensure
       tempfile.close
       tempfile.unlink
-    end
-
-    def with_tty(&block)
-      $stdin.stub(:tty?, true, &block)
     end
 
     def with_config_file(contents)


### PR DESCRIPTION
Previously, we were checking if $stdin was a TTY to determine if there was content to be read. As it turns out, this isn't really a good indicator, as content could always come later, and some folks run stree in CI when $stdin is not a TTY and still pass filenames.

Instead, we now check if no filenames were passed, and in that case we attempt to read from $stdin.

Fixes #159 