### PR TITLE
Raise ParseError on missing end for else statement

### DIFF
--- a/lib/syntax_tree/parser.rb
+++ b/lib/syntax_tree/parser.rb
@@ -1327,6 +1327,11 @@ module SyntaxTree
           token.is_a?(Kw) && %w[end ensure].include?(token.value)
         end
 
+      if index.nil?
+        message = "Cannot find expected else ending"
+        raise ParseError.new(message, *find_token_error(keyword.location))
+      end
+
       node = tokens[index]
       ending = node.value == "end" ? tokens.delete_at(index) : node
 

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -55,5 +55,15 @@ module SyntaxTree
     def test_handles_strings_with_non_terminated_embedded_expressions
       assert_raises(Parser::ParseError) { SyntaxTree.parse('"#{"') }
     end
+
+    def test_errors_on_else_missing_two_ends
+      assert_raises(Parser::ParseError) { SyntaxTree.parse(<<~RUBY) }
+        def foo
+          if something
+          else
+            call do
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
In `on_else`, the index of the last `end` or `ensure` token could potentially be `nil` on some cases, which led to trying to dereference the tokens array with `nil` - resulting in `no implicit conversion of nil into integer`.

This PR just raises a `ParseError` instead, pointing to the `else` token.