### PR TITLE
Fix current_environment usages to use accessor instead of instance variable

### DIFF
--- a/lib/syntax_tree/visitor/with_environment.rb
+++ b/lib/syntax_tree/visitor/with_environment.rb
@@ -64,19 +64,19 @@ module SyntaxTree
     # arguments
     def visit_params(node)
       node.requireds.each do |param|
-        @current_environment.add_local_definition(param, :argument)
+        current_environment.add_local_definition(param, :argument)
       end
 
       node.posts.each do |param|
-        @current_environment.add_local_definition(param, :argument)
+        current_environment.add_local_definition(param, :argument)
       end
 
       node.keywords.each do |param|
-        @current_environment.add_local_definition(param.first, :argument)
+        current_environment.add_local_definition(param.first, :argument)
       end
 
       node.optionals.each do |param|
-        @current_environment.add_local_definition(param.first, :argument)
+        current_environment.add_local_definition(param.first, :argument)
       end
 
       super
@@ -84,21 +84,21 @@ module SyntaxTree
 
     def visit_rest_param(node)
       name = node.name
-      @current_environment.add_local_definition(name, :argument) if name
+      current_environment.add_local_definition(name, :argument) if name
 
       super
     end
 
     def visit_kwrest_param(node)
       name = node.name
-      @current_environment.add_local_definition(name, :argument) if name
+      current_environment.add_local_definition(name, :argument) if name
 
       super
     end
 
     def visit_blockarg(node)
       name = node.name
-      @current_environment.add_local_definition(name, :argument) if name
+      current_environment.add_local_definition(name, :argument) if name
 
       super
     end
@@ -108,7 +108,7 @@ module SyntaxTree
       value = node.value
 
       if value.is_a?(SyntaxTree::Ident)
-        @current_environment.add_local_definition(value, :variable)
+        current_environment.add_local_definition(value, :variable)
       end
 
       super
@@ -119,7 +119,7 @@ module SyntaxTree
     # Visits for keeping track of variable and argument usages
     def visit_aref_field(node)
       name = node.collection.value
-      @current_environment.add_local_usage(name, :variable) if name
+      current_environment.add_local_usage(name, :variable) if name
 
       super
     end
@@ -128,10 +128,10 @@ module SyntaxTree
       value = node.value
 
       if value.is_a?(SyntaxTree::Ident)
-        definition = @current_environment.find_local(value.value)
+        definition = current_environment.find_local(value.value)
 
         if definition
-          @current_environment.add_local_usage(value, definition.type)
+          current_environment.add_local_usage(value, definition.type)
         end
       end
 

--- a/test/visitor_with_environment_test.rb
+++ b/test/visitor_with_environment_test.rb
@@ -406,5 +406,25 @@ module SyntaxTree
       assert_equal(2, argument.usages[0].start_line)
       assert_equal(4, argument.usages[1].start_line)
     end
+
+    def test_variables_in_the_top_level
+      tree = SyntaxTree.parse(<<~RUBY)
+        a = 123
+        a
+      RUBY
+
+      visitor = Collector.new
+      visitor.visit(tree)
+
+      assert_equal(0, visitor.arguments.length)
+      assert_equal(1, visitor.variables.length)
+
+      variable = visitor.variables["a"]
+      assert_equal(1, variable.definitions.length)
+      assert_equal(1, variable.usages.length)
+
+      assert_equal(1, variable.definitions[0].start_line)
+      assert_equal(2, variable.usages[0].start_line)
+    end
   end
 end


### PR DESCRIPTION
This PR fixes a mistake made in #157

All of the visits inside the `WithEnvironment` module should use the `current_environment` method instead of accessing the instance variable directly. Otherwise, the "global" environment is not instantiated. See the included test for reproduction.