### PR TITLE
Fix other environment cases

### DIFF
--- a/lib/syntax_tree/visitor/with_environment.rb
+++ b/lib/syntax_tree/visitor/with_environment.rb
@@ -67,9 +67,7 @@ module SyntaxTree
     # Visit for keeping track of local arguments, such as method and block
     # arguments
     def visit_params(node)
-      node.requireds.each do |param|
-        current_environment.add_local_definition(param, :argument)
-      end
+      add_argument_definitions(node.requireds)
 
       node.posts.each do |param|
         current_environment.add_local_definition(param, :argument)
@@ -133,6 +131,18 @@ module SyntaxTree
       end
 
       super
+    end
+
+    private
+
+    def add_argument_definitions(list)
+      list.each do |param|
+        if param.is_a?(SyntaxTree::MLHSParen)
+          add_argument_definitions(param.contents.parts)
+        else
+          current_environment.add_local_definition(param, :argument)
+        end
+      end
     end
   end
 end

--- a/lib/syntax_tree/visitor/with_environment.rb
+++ b/lib/syntax_tree/visitor/with_environment.rb
@@ -117,13 +117,6 @@ module SyntaxTree
     alias visit_pinned_var_ref visit_var_field
 
     # Visits for keeping track of variable and argument usages
-    def visit_aref_field(node)
-      name = node.collection.value
-      current_environment.add_local_usage(name, :variable) if name
-
-      super
-    end
-
     def visit_var_ref(node)
       value = node.value
 

--- a/lib/syntax_tree/visitor/with_environment.rb
+++ b/lib/syntax_tree/visitor/with_environment.rb
@@ -44,8 +44,12 @@ module SyntaxTree
       with_new_environment { super }
     end
 
+    # When we find a method invocation with a block, only the code that happens
+    # inside of the block needs a fresh environment. The method invocation
+    # itself happens in the same environment
     def visit_method_add_block(node)
-      with_new_environment { super }
+      visit(node.call)
+      with_new_environment { visit(node.block) }
     end
 
     def visit_def(node)

--- a/test/visitor_with_environment_test.rb
+++ b/test/visitor_with_environment_test.rb
@@ -533,5 +533,87 @@ module SyntaxTree
       assert_equal(2, argument.definitions[0].start_line)
       assert_equal(2, argument.usages[0].start_line)
     end
+
+    def test_nested_arguments
+      tree = SyntaxTree.parse(<<~RUBY)
+        [[1, [2, 3]]].each do |one, (two, three)|
+          one
+          two
+          three
+        end
+      RUBY
+
+      visitor = Collector.new
+      visitor.visit(tree)
+
+      assert_equal(3, visitor.arguments.length)
+      assert_equal(0, visitor.variables.length)
+
+      argument = visitor.arguments["one"]
+      assert_equal(1, argument.definitions.length)
+      assert_equal(1, argument.usages.length)
+
+      assert_equal(1, argument.definitions[0].start_line)
+      assert_equal(2, argument.usages[0].start_line)
+
+      argument = visitor.arguments["two"]
+      assert_equal(1, argument.definitions.length)
+      assert_equal(1, argument.usages.length)
+
+      assert_equal(1, argument.definitions[0].start_line)
+      assert_equal(3, argument.usages[0].start_line)
+
+      argument = visitor.arguments["three"]
+      assert_equal(1, argument.definitions.length)
+      assert_equal(1, argument.usages.length)
+
+      assert_equal(1, argument.definitions[0].start_line)
+      assert_equal(4, argument.usages[0].start_line)
+    end
+
+    def test_double_nested_arguments
+      tree = SyntaxTree.parse(<<~RUBY)
+        [[1, [2, 3]]].each do |one, (two, (three, four))|
+          one
+          two
+          three
+          four
+        end
+      RUBY
+
+      visitor = Collector.new
+      visitor.visit(tree)
+
+      assert_equal(4, visitor.arguments.length)
+      assert_equal(0, visitor.variables.length)
+
+      argument = visitor.arguments["one"]
+      assert_equal(1, argument.definitions.length)
+      assert_equal(1, argument.usages.length)
+
+      assert_equal(1, argument.definitions[0].start_line)
+      assert_equal(2, argument.usages[0].start_line)
+
+      argument = visitor.arguments["two"]
+      assert_equal(1, argument.definitions.length)
+      assert_equal(1, argument.usages.length)
+
+      assert_equal(1, argument.definitions[0].start_line)
+      assert_equal(3, argument.usages[0].start_line)
+
+      argument = visitor.arguments["three"]
+      assert_equal(1, argument.definitions.length)
+      assert_equal(1, argument.usages.length)
+
+      assert_equal(1, argument.definitions[0].start_line)
+      assert_equal(4, argument.usages[0].start_line)
+
+      argument = visitor.arguments["four"]
+      assert_equal(1, argument.definitions.length)
+      assert_equal(1, argument.usages.length)
+
+      assert_equal(1, argument.definitions[0].start_line)
+      assert_equal(5, argument.usages[0].start_line)
+    end
   end
 end

--- a/test/visitor_with_environment_test.rb
+++ b/test/visitor_with_environment_test.rb
@@ -506,5 +506,32 @@ module SyntaxTree
       assert_equal(1, variable.definitions[0].start_line)
       assert_equal(2, variable.usages[0].start_line)
     end
+
+    def test_double_aref_on_method_call
+      tree = SyntaxTree.parse(<<~RUBY)
+        object = MyObject.new
+        object["attributes"].find { |a| a["field"] == "expected" }["value"] = "changed"
+      RUBY
+
+      visitor = Collector.new
+      visitor.visit(tree)
+
+      assert_equal(1, visitor.arguments.length)
+      assert_equal(1, visitor.variables.length)
+
+      variable = visitor.variables["object"]
+      assert_equal(1, variable.definitions.length)
+      assert_equal(1, variable.usages.length)
+
+      assert_equal(1, variable.definitions[0].start_line)
+      assert_equal(2, variable.usages[0].start_line)
+
+      argument = visitor.arguments["a"]
+      assert_equal(1, argument.definitions.length)
+      assert_equal(1, argument.usages.length)
+
+      assert_equal(2, argument.definitions[0].start_line)
+      assert_equal(2, argument.usages[0].start_line)
+    end
   end
 end


### PR DESCRIPTION
I found a few issues in the implementation related to aref_field, method_add_block and nested arguments.

### ARefField

This boils down to a var_ref, so we were actually counting them twice. Also, `visit_aref_field` would be unnecessarily complicated if the collection was a `Call`, which would need special treatment. Simply removing that visit makes it so that we only go through var_refs once and works when the collection is a `Call`

### MethodAddBlock

These nodes have two parts: the call and the block. Only the block requires a fresh environment block, the call occurs in the same environment that the node is found. E.g.:

```ruby
object = MyObject.new
# object is inside the call part of method_add_block, but it happens in the current environment
object["attributes"].find do |a|
  # only inside this block do we need a fresh environment
  a["field"] == "expected"
end
```

### Nested arguments

We weren't handling the case where required positional arguments were "nested". E.g.:

```ruby
[].each do |one, (two, (three, four))|
end
```

I used recursion to fix this one because (to my surprise) it seems that Ruby allows you to have as many layers as desired. I assume most cases will only have one level, but better to model what Ruby allows you to do.