### PR TITLE
Unskip test_multiple_inline_scripts on TruffleRuby

### DIFF
--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -148,7 +148,6 @@ module SyntaxTree
     end
 
     def test_multiple_inline_scripts
-      skip if RUBY_ENGINE == "truffleruby" # Relies on a thread-safe StringIO
       stdio, = capture_io { SyntaxTree::CLI.run(%w[format -e 1+1 -e 2+2]) }
       assert_equal(["1 + 1", "2 + 2"], stdio.split("\n").sort)
     end


### PR DESCRIPTION
* StringIO is thread-safe now so this test should pass reliably.