### PR TITLE
Allow formatting code with a different base level of indentation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     syntax_tree (5.0.1)
-      prettier_print (>= 1.1.0)
+      prettier_print (>= 1.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -14,7 +14,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
-    prettier_print (1.1.0)
+    prettier_print (1.2.0)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.6.0)

--- a/lib/syntax_tree.rb
+++ b/lib/syntax_tree.rb
@@ -44,6 +44,10 @@ module SyntaxTree
   # It shouldn't really be changed except in very niche circumstances.
   DEFAULT_RUBY_VERSION = Formatter::SemanticVersion.new(RUBY_VERSION).freeze
 
+  # The default indentation level for formatting. We allow changing this so
+  # that Syntax Tree can format arbitrary parts of a document.
+  DEFAULT_INDENTATION = 0
+
   # This is a hook provided so that plugins can register themselves as the
   # handler for a particular file type.
   def self.register_handler(extension, handler)
@@ -61,12 +65,13 @@ module SyntaxTree
   def self.format(
     source,
     maxwidth = DEFAULT_PRINT_WIDTH,
+    base_indentation = DEFAULT_INDENTATION,
     options: Formatter::Options.new
   )
     formatter = Formatter.new(source, [], maxwidth, options: options)
     parse(source).format(formatter)
 
-    formatter.flush
+    formatter.flush(base_indentation)
     formatter.output.join
   end
 

--- a/lib/syntax_tree/formatter.rb
+++ b/lib/syntax_tree/formatter.rb
@@ -84,10 +84,10 @@ module SyntaxTree
       @target_ruby_version = options.target_ruby_version
     end
 
-    def self.format(source, node)
+    def self.format(source, node, base_indentation = 0)
       q = new(source, [])
       q.format(node)
-      q.flush
+      q.flush(base_indentation)
       q.output.join
     end
 

--- a/syntax_tree.gemspec
+++ b/syntax_tree.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
-  spec.add_dependency "prettier_print", ">= 1.1.0"
+  spec.add_dependency "prettier_print", ">= 1.2.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest"

--- a/test/formatting_test.rb
+++ b/test/formatting_test.rb
@@ -27,5 +27,37 @@ module SyntaxTree
 
       assert_equal(source, SyntaxTree.format(source))
     end
+
+    def test_formatting_with_different_indentation_level
+      source = <<~SOURCE
+        def foo
+          puts "a"
+        end
+      SOURCE
+
+      # Default indentation
+      assert_equal(source, SyntaxTree.format(source))
+
+      # Level 2
+      assert_equal(<<-EXPECTED.chomp, SyntaxTree.format(source, 80, 2).rstrip)
+  def foo
+    puts "a"
+  end
+      EXPECTED
+
+      # Level 4
+      assert_equal(<<-EXPECTED.chomp, SyntaxTree.format(source, 80, 4).rstrip)
+    def foo
+      puts "a"
+    end
+      EXPECTED
+
+      # Level 6
+      assert_equal(<<-EXPECTED.chomp, SyntaxTree.format(source, 80, 6).rstrip)
+      def foo
+        puts "a"
+      end
+      EXPECTED
+    end
   end
 end


### PR DESCRIPTION
Being able to override the base level of indentation allows us to format parts of a document that may be nested. This will allow the Ruby LSP to implement range formatting.

For example,
```ruby
class Foo
  def bar # if we select only the bar method definition for formatting, we need to start from indentation level 2
    puts "Hello"
  end
end
```

The necessary changes in prettier print are here https://github.com/ruby-syntax-tree/prettier_print/pull/4.

### Concerns

Currently, the implementation adds the new base indentation to the last new line of the formatted source. For example,
```ruby
  def foo
    puts "level 2"
  end
   # <-- Two spaces are added after this new line as well
```

I'm not sure if this is coming from Syntax Tree or prettier print. This is why we currently have the `rstrip` in the tests.