### PR TITLE
Format binary << operator

### DIFF
--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -2095,16 +2095,11 @@ module SyntaxTree
         q.group { q.format(left) }
         q.text(" ") unless power
 
-        if operator == :<<
-          q.text("<< ")
-          q.format(right)
-        else
-          q.group do
-            q.text(operator.name)
-            q.indent do
-              power ? q.breakable_empty : q.breakable_space
-              q.format(right)
-            end
+        q.group do
+          q.text(operator.name)
+          q.indent do
+            power ? q.breakable_empty : q.breakable_space
+            q.format(right)
           end
         end
       end

--- a/test/fixtures/binary.rb
+++ b/test/fixtures/binary.rb
@@ -5,6 +5,11 @@ foo << bar
 %
 foo**bar
 %
+foo << barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr << barrrrrrrrrrrrr << barrrrrrrrrrrrrrrrrr
+-
+foo << barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr << barrrrrrrrrrrrr <<
+  barrrrrrrrrrrrrrrrrr
+%
 foo * barrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr
 -
 foo *


### PR DESCRIPTION
### Why was this change necessary?

The << operator would not collapse in expressions like:

```
do_keyword << whitespace? << parameters.aka(:parameters).maybe << code.aka(:body) << end_keyword.maybe
```

### How does it address the problem?

We remove the condition for which << would not break

### Are there any side effects?

I'm not sure, maybe this condition was here for a good reason but it wasn't covered by the tests.

Fixes #215