### PR TITLE
Add link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Syntax Tree is a suite of tools built on top of the internal CRuby parser. It pr
 
 It is built with only standard library dependencies. It additionally ships with a plugin system so that you can build your own syntax trees from other languages and incorporate these tools.
 
+[RDoc Documentation](https://ruby-syntax-tree.github.io/syntax_tree/)
+
 - [Installation](#installation)
 - [CLI](#cli)
   - [ast](#ast)


### PR DESCRIPTION
I was looking in the README for a link to the docs, I only noticed afterwards that it was in the repo description.

cc @vinistock 