### PR TITLE
Add and ignore textDocument/documentColor

### DIFF
--- a/lib/syntax_tree/language_server.rb
+++ b/lib/syntax_tree/language_server.rb
@@ -111,6 +111,8 @@ module SyntaxTree
           write(id: request[:id], result: PP.pp(SyntaxTree.parse(store[uri]), +""))
         when Request[method: %r{\$/.+}]
           # ignored
+        when Request[method: "textDocument/documentColor", params: { textDocument: { uri: :any } }]
+          # ignored
         else
           raise ArgumentError, "Unhandled: #{request}"
         end


### PR DESCRIPTION
My editor is sending textDocument/documentColor request to language servers. syntax_tree however raise ArgumentError when received the `textDocument/documentColor`.

Not sure if you are okay for adding but ignore `textDocument/documentColor` in syntax_tree.