### PR TITLE
Fix #234

### DIFF
--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -6160,7 +6160,7 @@ module SyntaxTree
         # want to force it to not be a ternary, like if the predicate is an
         # assignment because it's hard to read.
         case node.predicate
-        when Assign, Command, CommandCall, MAssign, OpAssign
+        when Assign, Binary, Command, CommandCall, MAssign, OpAssign
           return false
         when Not
           return false unless node.predicate.parentheses?
@@ -6183,10 +6183,10 @@ module SyntaxTree
       # and default instead to breaking them into multiple lines.
       def ternaryable?(statement)
         case statement
-        when AliasNode, Assign, Break, Command, CommandCall, Heredoc, IfNode,
-             IfOp, Lambda, MAssign, Next, OpAssign, RescueMod, ReturnNode,
-             Super, Undef, UnlessNode, UntilNode, VoidStmt, WhileNode,
-             YieldNode, ZSuper
+        when AliasNode, Assign, Break, Command, CommandCall, Defined, Heredoc,
+             IfNode, IfOp, Lambda, MAssign, Next, OpAssign, RescueMod,
+             ReturnNode, Super, Undef, UnlessNode, UntilNode, VoidStmt,
+             WhileNode, YieldNode, ZSuper
           # This is a list of nodes that should not be allowed to be a part of a
           # ternary clause.
           false

--- a/test/fixtures/if.rb
+++ b/test/fixtures/if.rb
@@ -67,3 +67,10 @@ end
 if true # comment1
   # comment2
 end
+%
+result =
+  if false && val = 1
+    "A"
+  else
+    "B"
+  end


### PR DESCRIPTION
Fixes #234 

We shouldn't attempt to ternary transform if-else statements if they contain a binary node in their predicate. The operator precedence gets too confusing. Just leave them be.