### PR TITLE
Only write files when content changes

### DIFF
--- a/lib/syntax_tree/cli.rb
+++ b/lib/syntax_tree/cli.rb
@@ -303,10 +303,11 @@ module SyntaxTree
             options.print_width,
             options: options.formatter_options
           )
+        changed = source != formatted
 
-        File.write(filepath, formatted) if item.writable?
+        File.write(filepath, formatted) if item.writable? && changed
 
-        color = source == formatted ? Color.gray(filepath) : filepath
+        color = changed ? filepath : Color.gray(filepath)
         delta = ((Time.now - start) * 1000).round
 
         puts "#{color} #{delta}ms"


### PR DESCRIPTION
Previously the CLI would call `File.write` for every file, even if the contents was unchanged. This unnecessary filesystem churn can have a knock-on effect on other tools which may be watching directories for changes (e.g. IDEs). This commit updates the `stree write` command so that it only performs a write when the file contents has changed.

There is also a very slight performance improvement in the 'happy path' when files are already formatted. Measuring runtime on Discourse's core codebase (4.3k ruby files), when all files are already formatted:

| | run 1 | run 2 | run 3 | mean |
|--|--|--|--|--|
|Before| 26.4 | 27.1 | 26.1 | **26.5s** |
|After | 24.3 | 23.8 | 24.4 | **24.2s** |

Presumably this difference would be larger in environments with slower filesystems.