### PR TITLE
Fix: Handle Fiddle::DLError

### DIFF
--- a/lib/syntax_tree/yarv/instruction_sequence.rb
+++ b/lib/syntax_tree/yarv/instruction_sequence.rb
@@ -70,7 +70,7 @@ module SyntaxTree
             [Fiddle::TYPE_VOIDP] * 3,
             Fiddle::TYPE_VOIDP
           )
-        rescue NameError
+        rescue NameError, Fiddle::DLError
         end
 
       # This object is used to track the size of the stack at any given time. It


### PR DESCRIPTION
On Ruby 3.2 and fiddle 1.1.1, this library doesn't work: ```
c:/develop/ruby32/lib/ruby/gems/3.2.0/gems/syntax_tree-5.2.0/lib/syntax_tree/yarv/instruction_sequence.rb:69:in `[]': unknown symbol "rb_iseq_load" (Fiddle::DLError)
        from c:/develop/ruby32/lib/ruby/gems/3.2.0/gems/syntax_tree-5.2.0/lib/syntax_tree/yarv/instruction_sequence.rb:69:in `<class:InstructionSequence>'
        from c:/develop/ruby32/lib/ruby/gems/3.2.0/gems/syntax_tree-5.2.0/lib/syntax_tree/yarv/instruction_sequence.rb:9:in `<module:YARV>'
        from c:/develop/ruby32/lib/ruby/gems/3.2.0/gems/syntax_tree-5.2.0/lib/syntax_tree/yarv/instruction_sequence.rb:5:in `<module:SyntaxTree>'
        from c:/develop/ruby32/lib/ruby/gems/3.2.0/gems/syntax_tree-5.2.0/lib/syntax_tree/yarv/instruction_sequence.rb:3:in `<top (required)>'
        from c:/develop/ruby32/lib/ruby/gems/3.2.0/gems/syntax_tree-5.2.0/lib/syntax_tree.rb:35:in `require_relative'
        from c:/develop/ruby32/lib/ruby/gems/3.2.0/gems/syntax_tree-5.2.0/lib/syntax_tree.rb:35:in `<top (required)>'
        from <internal:c:/develop/ruby32/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:160:in `require'
        from <internal:c:/develop/ruby32/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:160:in `rescue in require'
        from <internal:c:/develop/ruby32/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:149:in `require'
        from c:/develop/ruby32/lib/ruby/3.2.0/irb/init.rb:423:in `block in load_modules'
        from c:/develop/ruby32/lib/ruby/3.2.0/irb/init.rb:421:in `each'
        from c:/develop/ruby32/lib/ruby/3.2.0/irb/init.rb:421:in `load_modules'
        from c:/develop/ruby32/lib/ruby/3.2.0/irb/init.rb:21:in `setup'
        from c:/develop/ruby32/lib/ruby/3.2.0/irb.rb:414:in `start'
        from c:/develop/ruby32/lib/ruby/gems/3.2.0/gems/irb-1.6.2/exe/irb:11:in `<top (required)>'
        from c:/develop/ruby32/bin/irb:25:in `load'
        from c:/develop/ruby32/bin/irb:25:in `<main>'
```
This PR fixes this error.
