### PR TITLE
Check for existence of parser test file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,8 @@ Rake::TestTask.new(:test) do |t|
   test_files = FileList["test/**/*_test.rb"]
 
   # This is a big test file from the parser gem that tests its functionality.
-  test_files << "test/suites/parser/test/test_parser.rb"
+  parser_test_file = "test/suites/parser/test/test_parser.rb"
+  test_files << parser_test_file if File.exist?(parser_test_file)
 
   t.test_files = test_files
 end


### PR DESCRIPTION
Check that the file exists before adding it to Rake's list of test files. If somebody hasn't pulled the submodule, the tests will not raise an exception.