### PR TITLE
Combine `LambdaVar` node with `BlockVar`

### DIFF
--- a/lib/syntax_tree/dsl.rb
+++ b/lib/syntax_tree/dsl.rb
@@ -146,8 +146,13 @@ module SyntaxTree
     end
 
     # Create a new BlockVar node.
-    def BlockVar(params, locals)
-      BlockVar.new(params: params, locals: locals, location: Location.default)
+    def BlockVar(params, locals, pipe)
+      BlockVar.new(
+        params: params,
+        locals: locals,
+        location: Location.default,
+        pipe: pipe
+      )
     end
 
     # Create a new BlockArg node.
@@ -549,11 +554,6 @@ module SyntaxTree
         statements: statements,
         location: Location.default
       )
-    end
-
-    # Create a new LambdaVar node.
-    def LambdaVar(params, locals)
-      LambdaVar.new(params: params, locals: locals, location: Location.default)
     end
 
     # Create a new LBrace node.

--- a/lib/syntax_tree/field_visitor.rb
+++ b/lib/syntax_tree/field_visitor.rb
@@ -526,14 +526,6 @@ module SyntaxTree
         end
       end
 
-      def visit_lambda_var(node)
-        node(node, "lambda_var") do
-          field("params", node.params)
-          list("locals", node.locals) if node.locals.any?
-          comments(node)
-        end
-      end
-
       def visit_lbrace(node)
         visit_token(node, "lbrace")
       end

--- a/lib/syntax_tree/mutation_visitor.rb
+++ b/lib/syntax_tree/mutation_visitor.rb
@@ -500,11 +500,6 @@ module SyntaxTree
         )
       end
 
-      # Visit a LambdaVar node.
-      def visit_lambda_var(node)
-        node.copy(params: visit(node.params), locals: visit_all(node.locals))
-      end
-
       # Visit a LBrace node.
       def visit_lbrace(node)
         node.copy

--- a/lib/syntax_tree/parser.rb
+++ b/lib/syntax_tree/parser.rb
@@ -937,7 +937,8 @@ module SyntaxTree
       BlockVar.new(
         params: params,
         locals: locals || [],
-        location: beginning.location.to(ending.location)
+        location: beginning.location.to(ending.location),
+        pipe: true
       )
     end
 
@@ -2296,10 +2297,11 @@ module SyntaxTree
             Paren.new(
               lparen: params.lparen,
               contents:
-                LambdaVar.new(
+                BlockVar.new(
                   params: params.contents,
                   locals: locals,
-                  location: location
+                  location: location,
+                  pipe: false
                 ),
               location: params.location
             )
@@ -2324,8 +2326,13 @@ module SyntaxTree
 
           # In this case we've gotten to the plain set of parameters. In this
           # case there cannot be lambda locals, so we will wrap the parameters
-          # into a lambda var that has no locals.
-          LambdaVar.new(params: params, locals: [], location: params.location)
+          # into a block var that has no locals.
+          BlockVar.new(
+            params: params,
+            locals: [],
+            location: params.location,
+            pipe: false
+          )
         end
 
       start_char = find_next_statement_start(opening.location.end_char)
@@ -2345,12 +2352,17 @@ module SyntaxTree
     end
 
     # :call-seq:
-    #   on_lambda_var: (Params params, Array[ Ident ] locals) -> LambdaVar
+    #   on_lambda_var: (Params params, Array[ Ident ] locals) -> BlockVar
     def on_lambda_var(params, locals)
       location = params.location
       location = location.to(locals.last.location) if locals.any?
 
-      LambdaVar.new(params: params, locals: locals || [], location: location)
+      BlockVar.new(
+        params: params,
+        locals: locals || [],
+        location: location,
+        pipe: false
+      )
     end
 
     # Ripper doesn't support capturing lambda local variables until 3.2. To

--- a/lib/syntax_tree/visitor.rb
+++ b/lib/syntax_tree/visitor.rb
@@ -218,9 +218,6 @@ module SyntaxTree
     # Visit a Lambda node.
     alias visit_lambda visit_child_nodes
 
-    # Visit a LambdaVar node.
-    alias visit_lambda_var visit_child_nodes
-
     # Visit a LBrace node.
     alias visit_lbrace visit_child_nodes
 

--- a/lib/syntax_tree/yarv/compiler.rb
+++ b/lib/syntax_tree/yarv/compiler.rb
@@ -1103,10 +1103,6 @@ module SyntaxTree
         iseq.send(YARV.calldata(:lambda, 0, CallData::CALL_FCALL), lambda_iseq)
       end
 
-      def visit_lambda_var(node)
-        visit_block_var(node)
-      end
-
       def visit_massign(node)
         visit(node.value)
         iseq.dup

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -635,6 +635,25 @@ module SyntaxTree
       source = "->(value) { value * 2 }"
 
       assert_node(Lambda, source)
+
+      at = location(chars: 3..8)
+      assert_node(BlockVar, source, at: at) { |node| node.params.contents }
+    end
+
+    def test_lambda_no_parens
+      source = "-> value { value * 2 }"
+
+      assert_node(Lambda, source)
+
+      at = location(chars: 3..8)
+      assert_node(BlockVar, source, at: at, &:params)
+    end
+
+    def test_lambda_braces
+      source = "lambda { |value| value * 2 }"
+
+      at = location(chars: 9..16)
+      assert_node(BlockVar, source, at: at) { |node| node.block.block_var }
     end
 
     def test_lambda_do


### PR DESCRIPTION
Related to #278.

This PR combines the `LambdaVar` node with `BlockVar`. Now, any params on blocks or lambdas will be represented by a `BlockVar` node. This removes an unnecessary node from syntax tree, which simplifies logic and brings syntax tree closer to other Ruby AST implementations.