### PR TITLE
Add `MutationVisitor#remove` API to remove nodes from the tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,14 +611,17 @@ visitor.mutate("IfNode[predicate: Assign | OpAssign]") do |node|
   node.copy(predicate: predicate)
 end
 
-source = "if a = 1; end"
+# remove `do_more_work` method call node
+visitor.remove("SyntaxTree::VCall[value: SyntaxTree::Ident[value: 'do_more_work']]")
+
+source = "if a = 1; perform_work; do_more_work; end"
 program = SyntaxTree.parse(source)
 
 SyntaxTree::Formatter.format(source, program)
-# => "if a = 1\nend\n"
+# => "if a = 1\n  perform_work\n  do_more_work\nend\n"
 
 SyntaxTree::Formatter.format(source, program.accept(visitor))
-# => "if (a = 1)\nend\n"
+# => "if (a = 1)\n  perform_work\nend\n"
 ```
 
 ### WithScope

--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -9324,6 +9324,48 @@ module SyntaxTree
     end
   end
 
+  # RemovedNode is a blank node used in places of nodes that have been removed.
+  class RemovedNode < Node
+    # [Array[ Comment | EmbDoc ]] the comments attached to this node
+    attr_reader :comments
+
+    def initialize(location:)
+      @location = location
+      @comments = []
+    end
+
+    def accept(visitor)
+      visitor.visit_removed_node(self)
+    end
+
+    def child_nodes
+      []
+    end
+
+    def copy(location: self.location)
+      node = RemovedNode.new(
+        location: location
+      )
+
+      node.comments.concat(comments.map(&:copy))
+
+      node
+    end
+
+    alias deconstruct child_nodes
+
+    def deconstruct_keys(_keys)
+      { location: location, comments: comments }
+    end
+
+    def format(_q)
+    end
+
+    def ===(other)
+      other.is_a?(RemovedNode)
+    end
+  end
+
   # RescueEx represents the list of exceptions being rescued in a rescue clause.
   #
   #     begin

--- a/lib/syntax_tree/visitor.rb
+++ b/lib/syntax_tree/visitor.rb
@@ -320,6 +320,9 @@ module SyntaxTree
     # Visit a RegexpLiteral node.
     alias visit_regexp_literal visit_child_nodes
 
+    # Visit a RemovedNode node.
+    alias visit_removed_node visit_child_nodes
+
     # Visit a Rescue node.
     alias visit_rescue visit_child_nodes
 

--- a/test/mutation_test.rb
+++ b/test/mutation_test.rb
@@ -21,6 +21,35 @@ module SyntaxTree
       assert_equal(expected, SyntaxTree::Formatter.format(source, program))
     end
 
+    def test_removes_node
+      source = <<~RUBY
+        App.configure do |config|
+          config.config_value_a = 1
+          config.config_value_b = 2
+          config.config_value_c = 2
+        end
+      RUBY
+
+      expected = <<~RUBY
+        App.configure do |config|
+          config.config_value_a = 1
+
+          config.config_value_c = 2
+        end
+      RUBY
+
+      mutation_visitor = SyntaxTree.mutation do |mutation|
+        mutation.remove("SyntaxTree::Assign[
+          target: SyntaxTree::Field[
+            name: SyntaxTree::Ident[value: 'config_value_b']
+          ],
+        ]")
+      end
+
+      program = SyntaxTree.parse(source).accept(mutation_visitor)
+      assert_equal(expected, SyntaxTree::Formatter.format(source, program))
+    end
+
     private
 
     def build_mutation


### PR DESCRIPTION
This PR allows extends `MutationVisitor` to allow removing nodes from the tree.
The API we are going with is having `remove` helper method along with `mutate` to define patterns for nodes to be removed from the tree. 
It's not a necessity but provides a nicer API compared to:
```ruby
visitor.mutate("<pattern for node to be removed>") do |node|
   RemovedNode.new
end
```
allowing for `visitor.remove("<pattern for node to be removed>")` to be used.

Under the hood we are mutating the tree by substituting nodes that match the removal pattern with an instance of `RemovedNode` which purpose is to keep the tree valid and be formatted as an empty string during tree dumping.
