### PR TITLE
Fix CI for TruffleRuby

### DIFF
--- a/lib/syntax_tree/reflection.rb
+++ b/lib/syntax_tree/reflection.rb
@@ -176,7 +176,8 @@ module SyntaxTree
     program =
       SyntaxTree.parse(SyntaxTree.read(File.expand_path("node.rb", __dir__)))
 
-    main_statements = program.statements.body.last.bodystmt.statements.body
+    program_statements = program.statements
+    main_statements = program_statements.body.last.bodystmt.statements.body
     main_statements.each_with_index do |main_statement, main_statement_index|
       # Ensure we are only looking at class declarations.
       next unless main_statement.is_a?(SyntaxTree::ClassDeclaration)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-require "simplecov"
-SimpleCov.start do
-  add_filter("idempotency_test.rb") unless ENV["CI"]
-  add_group("lib", "lib")
-  add_group("test", "test")
+unless RUBY_ENGINE == "truffleruby"
+  require "simplecov"
+  SimpleCov.start do
+    add_filter("idempotency_test.rb") unless ENV["CI"]
+    add_group("lib", "lib")
+    add_group("test", "test")
+  end
 end
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,36 +13,38 @@ $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "syntax_tree"
 require "syntax_tree/cli"
 
-# Here we are going to establish type verification whenever a new node is
-# created. We do this through the reflection module, which in turn parses the
-# source code of the node classes.
-require "syntax_tree/reflection"
-SyntaxTree::Reflection.nodes.each do |name, node|
-  next if name == :Statements
+unless RUBY_ENGINE == "truffleruby"
+  # Here we are going to establish type verification whenever a new node is
+  # created. We do this through the reflection module, which in turn parses the
+  # source code of the node classes.
+  require "syntax_tree/reflection"
+  SyntaxTree::Reflection.nodes.each do |name, node|
+    next if name == :Statements
 
-  clazz = SyntaxTree.const_get(name)
-  parameters = clazz.instance_method(:initialize).parameters
+    clazz = SyntaxTree.const_get(name)
+    parameters = clazz.instance_method(:initialize).parameters
 
-  # First, verify that all of the parameters listed in the list of attributes.
-  # If there are any parameters that aren't listed in the attributes, then
-  # something went wrong with the parsing in the reflection module.
-  raise unless (parameters.map(&:last) - node.attributes.keys).empty?
+    # First, verify that all of the parameters listed in the list of attributes.
+    # If there are any parameters that aren't listed in the attributes, then
+    # something went wrong with the parsing in the reflection module.
+    raise unless (parameters.map(&:last) - node.attributes.keys).empty?
 
-  # Now we're going to use an alias chain to redefine the initialize method to
-  # include type checking.
-  clazz.alias_method(:initialize_without_verify, :initialize)
-  clazz.define_method(:initialize) do |**kwargs|
-    kwargs.each do |kwarg, value|
-      attribute = node.attributes.fetch(kwarg)
+    # Now we're going to use an alias chain to redefine the initialize method to
+    # include type checking.
+    clazz.alias_method(:initialize_without_verify, :initialize)
+    clazz.define_method(:initialize) do |**kwargs|
+      kwargs.each do |kwarg, value|
+        attribute = node.attributes.fetch(kwarg)
 
-      unless attribute.type === value
-        raise TypeError,
-              "invalid type for #{name}##{kwarg}, expected " \
-                "#{attribute.type.inspect}, got #{value.inspect}"
+        unless attribute.type === value
+          raise TypeError,
+                "invalid type for #{name}##{kwarg}, expected " \
+                  "#{attribute.type.inspect}, got #{value.inspect}"
+        end
       end
-    end
 
-    initialize_without_verify(**kwargs)
+      initialize_without_verify(**kwargs)
+    end
   end
 end
 


### PR DESCRIPTION
Example failure:
https://github.com/ruby-syntax-tree/syntax_tree/actions/runs/4276174338/jobs/7444068581

```
$ bundle exec rake test
Coverage report generated for Unit Tests to /home/runner/work/syntax_tree/syntax_tree/coverage. 5963 / 14181 LOC (42.05%) covered.
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
/home/runner/work/syntax_tree/syntax_tree/lib/syntax_tree/reflection.rb:179:in `<module:Reflection>': undefined method `statements' for nil:NilClass (NoMethodError)
	from /home/runner/work/syntax_tree/syntax_tree/lib/syntax_tree/reflection.rb:7:in `<module:SyntaxTree>'
	from /home/runner/work/syntax_tree/syntax_tree/lib/syntax_tree/reflection.rb:3:in `<top (required)>'
	from <internal:core> core/kernel.rb:234:in `gem_original_require'
	from /home/runner/work/syntax_tree/syntax_tree/test/test_helper.rb:17:in `<top (required)>'
	from <internal:core> core/kernel.rb:293:in `require_relative'
	from /home/runner/work/syntax_tree/syntax_tree/test/cli_test.rb:3:in `<top (required)>'
	from <internal:core> core/kernel.rb:234:in `gem_original_require'
	from /home/runner/work/syntax_tree/syntax_tree/vendor/bundle/truffleruby/3.1.3.3/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /home/runner/work/syntax_tree/syntax_tree/vendor/bundle/truffleruby/3.1.3.3/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `select'
	from /home/runner/work/syntax_tree/syntax_tree/vendor/bundle/truffleruby/3.1.3.3/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
```