### PR TITLE
Fix lambda local locations

### DIFF
--- a/lib/syntax_tree/parser.rb
+++ b/lib/syntax_tree/parser.rb
@@ -2391,8 +2391,14 @@ module SyntaxTree
         }
       }
 
+      parent_line = lineno - 1
+      parent_column =
+        consume_token(Semicolon).location.start_column - tokens[index][0][1]
+
       tokens[(index + 1)..].each_with_object([]) do |token, locals|
         (lineno, column), type, value, = token
+        column += parent_column if lineno == 1
+        lineno += parent_line
 
         # Make the state transition for the parser. If there isn't a transition
         # from the current state to a new state for this type, then we're in a

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -74,5 +74,53 @@ module SyntaxTree
         \xC5
       RUBY
     end
+
+    def test_lambda_vars_with_parameters_location
+      tree = SyntaxTree.parse(<<~RUBY)
+        # comment
+        # comment
+        ->(_i; a) { a }
+      RUBY
+
+      local_location =
+        tree.statements.body.last.params.contents.locals.first.location
+
+      assert_equal(3, local_location.start_line)
+      assert_equal(3, local_location.end_line)
+      assert_equal(7, local_location.start_column)
+      assert_equal(8, local_location.end_column)
+    end
+
+    def test_lambda_vars_location
+      tree = SyntaxTree.parse(<<~RUBY)
+        # comment
+        # comment
+        ->(; a) { a }
+      RUBY
+
+      local_location =
+        tree.statements.body.last.params.contents.locals.first.location
+
+      assert_equal(3, local_location.start_line)
+      assert_equal(3, local_location.end_line)
+      assert_equal(5, local_location.start_column)
+      assert_equal(6, local_location.end_column)
+    end
+
+    def test_multiple_lambda_vars_location
+      tree = SyntaxTree.parse(<<~RUBY)
+        # comment
+        # comment
+        ->(; a, b, c) { a }
+      RUBY
+
+      local_location =
+        tree.statements.body.last.params.contents.locals.last.location
+
+      assert_equal(3, local_location.start_line)
+      assert_equal(3, local_location.end_line)
+      assert_equal(11, local_location.start_column)
+      assert_equal(12, local_location.end_column)
+    end
   end
 end


### PR DESCRIPTION
Lambda locals were not taking parent lines and columns into consideration in its location.