### PR TITLE
Fix WithScope visits for deconstructed block params

### DIFF
--- a/lib/syntax_tree/with_scope.rb
+++ b/lib/syntax_tree/with_scope.rb
@@ -221,7 +221,11 @@ module SyntaxTree
 
     def add_argument_definitions(list)
       list.each do |param|
-        if param.is_a?(SyntaxTree::MLHSParen)
+        case param
+        when ArgStar
+          value = param.value
+          current_scope.add_local_definition(value, :argument) if value
+        when MLHSParen
           add_argument_definitions(param.contents.parts)
         else
           current_scope.add_local_definition(param, :argument)

--- a/test/with_scope_test.rb
+++ b/test/with_scope_test.rb
@@ -198,6 +198,25 @@ module SyntaxTree
       assert_argument(collector, "i", definitions: [2], usages: [3])
     end
 
+    def test_collecting_destructured_block_arguments
+      collector = Collector.collect(<<~RUBY)
+        [].each do |(a, *b)|
+        end
+      RUBY
+
+      assert_equal(2, collector.arguments.length)
+      assert_argument(collector, "b", definitions: [1])
+    end
+
+    def test_collecting_anonymous_destructured_block_arguments
+      collector = Collector.collect(<<~RUBY)
+        [].each do |(a, *)|
+        end
+      RUBY
+
+      assert_equal(1, collector.arguments.length)
+    end
+
     def test_collecting_one_line_block_arguments
       collector = Collector.collect(<<~RUBY)
         def foo


### PR DESCRIPTION
Deconstructed block parameters using splats were passing an `ArgStar` instead of an `Ident` to `add_local_definition` resulting in a `no method delete_suffix` error.

Also added more tests!