### PR TITLE
Add support for more locals in WithScope

### DIFF
--- a/lib/syntax_tree/with_scope.rb
+++ b/lib/syntax_tree/with_scope.rb
@@ -217,6 +217,63 @@ module SyntaxTree
       super
     end
 
+    # When using regex named capture groups, vcalls might actually be a variable
+    def visit_vcall(node)
+      value = node.value
+      definition = current_scope.find_local(value.value)
+      current_scope.add_local_usage(value, definition.type) if definition
+
+      super
+    end
+
+    # Visit for capturing local variables defined in regex named capture groups
+    def visit_binary(node)
+      if node.operator == :=~
+        left = node.left
+
+        if left.is_a?(RegexpLiteral) && left.parts.length == 1 &&
+             left.parts.first.is_a?(TStringContent)
+          content = left.parts.first
+
+          value = content.value
+          location = content.location
+          start_line = location.start_line
+
+          Regexp
+            .new(value, Regexp::FIXEDENCODING)
+            .names
+            .each do |name|
+              offset = value.index(/\(\?<#{Regexp.escape(name)}>/)
+              line = start_line + value[0...offset].count("\n")
+
+              # We need to add 3 to account for these three characters
+              # prefixing a named capture (?<
+              column = location.start_column + offset + 3
+              if value[0...offset].include?("\n")
+                column =
+                  value[0...offset].length - value[0...offset].rindex("\n") +
+                    3 - 1
+              end
+
+              ident_location =
+                Location.new(
+                  start_line: line,
+                  start_char: location.start_char + offset,
+                  start_column: column,
+                  end_line: line,
+                  end_char: location.start_char + offset + name.length,
+                  end_column: column + name.length
+                )
+
+              identifier = Ident.new(value: name, location: ident_location)
+              current_scope.add_local_definition(identifier, :variable)
+            end
+        end
+      end
+
+      super
+    end
+
     private
 
     def add_argument_definitions(list)

--- a/lib/syntax_tree/with_scope.rb
+++ b/lib/syntax_tree/with_scope.rb
@@ -189,6 +189,15 @@ module SyntaxTree
       super
     end
 
+    def visit_block_var(node)
+      node.locals.each do |local|
+        current_scope.add_local_definition(local, :variable)
+      end
+
+      super
+    end
+    alias visit_lambda_var visit_block_var
+
     # Visit for keeping track of local variable definitions
     def visit_var_field(node)
       value = node.value

--- a/test/with_scope_test.rb
+++ b/test/with_scope_test.rb
@@ -356,6 +356,27 @@ module SyntaxTree
       assert_argument(collector, "four", definitions: [1], usages: [5])
     end
 
+    def test_block_locals
+      collector = Collector.collect(<<~RUBY)
+        [].each do |; a|
+        end
+      RUBY
+
+      assert_equal(1, collector.variables.length)
+
+      assert_variable(collector, "a", definitions: [1])
+    end
+
+    def test_lambda_locals
+      collector = Collector.collect(<<~RUBY)
+        ->(;a) { }
+      RUBY
+
+      assert_equal(1, collector.variables.length)
+
+      assert_variable(collector, "a", definitions: [1])
+    end
+
     def test_regex_named_capture_groups
       collector = Collector.collect(<<~RUBY)
         if /(?<one>\\w+)-(?<two>\\w+)/ =~ "something-else"

--- a/test/with_scope_test.rb
+++ b/test/with_scope_test.rb
@@ -117,11 +117,7 @@ module SyntaxTree
 
       assert_equal(2, collector.variables.length)
       assert_variable(collector, "a", definitions: [2], usages: [4, 5])
-      assert_variable(collector, "rest", definitions: [4])
-
-      # Rest is considered a vcall by the parser instead of a var_ref
-      # assert_equal(1, variable_rest.usages.length)
-      # assert_equal(6, variable_rest.usages[0].start_line)
+      assert_variable(collector, "rest", definitions: [4], usages: [6])
     end
 
     if RUBY_VERSION >= "3.1"


### PR DESCRIPTION
Add support for lambda locals, block locals and regexp named capture groups. As a side effect, because we're now visiting `vcall`, this also fixed the usages for pinned rest variables.