### PR TITLE
Handle `nil` symbol in BasicVisitor#visit

### DIFF
--- a/lib/syntax_tree/basic_visitor.rb
+++ b/lib/syntax_tree/basic_visitor.rb
@@ -103,7 +103,9 @@ module SyntaxTree
     end
 
     def visit(node)
-      node&.accept(self)
+      return if node.nil? || node.is_a?(Symbol)
+
+      node.accept(self)
     end
 
     def visit_all(nodes)

--- a/test/visitor_test.rb
+++ b/test/visitor_test.rb
@@ -22,6 +22,26 @@ module SyntaxTree
       assert_equal(%w[Foo foo Bar bar baz], visitor.visited_nodes)
     end
 
+    def test_visit_for_symbols
+      parsed_tree = SyntaxTree.parse(<<~RUBY)
+        def foo(**nil)
+        end
+
+        foo do |**nil|
+        end
+
+        ->(**nil) {}
+
+        case foo
+        in **nil
+        end
+      RUBY
+
+      visitor = DummyVisitor.new
+      visitor.visit(parsed_tree)
+      assert_equal(%w[foo], visitor.visited_nodes)
+    end
+
     class DummyVisitor < Visitor
       attr_reader :visited_nodes
 


### PR DESCRIPTION
In some scenarios, `node` may actually be the symbol `nil`. We weren't handling that and the visits would fail with `undefined method accept for nil:Symbol`.