### PR TITLE
Fix Ruby build on HEAD

### DIFF
--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -6767,6 +6767,7 @@ module SyntaxTree
       q.group do
         q.text(keyword)
         q.nest(keyword.length) { q.format(pattern) }
+        q.text(" then") if pattern.is_a?(RangeNode) && pattern.right.nil?
 
         unless statements.empty?
           q.indent do

--- a/lib/syntax_tree/parser.rb
+++ b/lib/syntax_tree/parser.rb
@@ -2132,13 +2132,20 @@ module SyntaxTree
       ending = consequent || consume_keyword(:end)
 
       statements_start = pattern
-      if (token = find_keyword(:then))
+      if (token = find_keyword_between(:then, pattern, statements))
         tokens.delete(token)
         statements_start = token
       end
 
       start_char =
         find_next_statement_start((token || statements_start).location.end_char)
+
+      # Ripper ignores parentheses on patterns, so we need to do the same in
+      # order to attach comments correctly to the pattern.
+      if source[start_char] == ")"
+        start_char = find_next_statement_start(start_char + 1)
+      end
+
       statements.bind(
         self,
         start_char,


### PR DESCRIPTION
This fixes two bugs. The first is that in an `in` clause, you need to use the `then` keyword or parentheses if the pattern you are matching is an endless range.

The second is that we are associating the `then` keyword with the wrong `in` clauses because they come in in reverse order and we're deleting them from the parent clauses incorrectly.