### PR TITLE
Args -> ArgumentsNode

### DIFF
--- a/lib/syntax_tree/dsl.rb
+++ b/lib/syntax_tree/dsl.rb
@@ -55,9 +55,9 @@ module SyntaxTree
       ArgParen.new(arguments: arguments, location: Location.default)
     end
 
-    # Create a new Args node.
-    def Args(parts)
-      Args.new(parts: parts, location: Location.default)
+    # Create a new ArgumentsNode node.
+    def ArgumentsNode(arguments)
+      ArgumentsNode.new(arguments: arguments, location: Location.default)
     end
 
     # Create a new ArgBlock node.

--- a/lib/syntax_tree/field_visitor.rb
+++ b/lib/syntax_tree/field_visitor.rb
@@ -94,9 +94,9 @@ module SyntaxTree
         end
       end
 
-      def visit_args(node)
-        node(node, "args") do
-          list("parts", node.parts)
+      def visit_arguments_node(node)
+        node(node, "arguments_node") do
+          list("arguments", node.arguments)
           comments(node)
         end
       end

--- a/lib/syntax_tree/index.rb
+++ b/lib/syntax_tree/index.rb
@@ -554,7 +554,7 @@ module SyntaxTree
                   node.location.start_column
                 )
 
-              node.arguments.parts.each do |argument|
+              node.arguments.arguments.each do |argument|
                 next unless argument.is_a?(SymbolLiteral)
                 name = argument.value.value.to_sym
 

--- a/lib/syntax_tree/mutation_visitor.rb
+++ b/lib/syntax_tree/mutation_visitor.rb
@@ -80,9 +80,9 @@ module SyntaxTree
         node.copy(arguments: visit(node.arguments))
       end
 
-      # Visit a Args node.
-      def visit_args(node)
-        node.copy(parts: visit_all(node.parts))
+      # Visit a ArgumentsNode node.
+      def visit_arguments_node(node)
+        node.copy(arguments: visit_all(node.arguments))
       end
 
       # Visit a ArgBlock node.

--- a/lib/syntax_tree/reflection.rb
+++ b/lib/syntax_tree/reflection.rb
@@ -213,13 +213,13 @@ module SyntaxTree
 
           # The arguments to the command are the attributes that we're defining.
           # We want to ensure that we're only defining one at a time.
-          if statement.arguments.parts.length != 1
+          if statement.arguments.arguments.length != 1
             raise "Declaring more than one attribute at a time is not permitted"
           end
 
           attribute =
             Attribute.new(
-              statement.arguments.parts.first.value.value.to_sym,
+              statement.arguments.arguments.first.value.value.to_sym,
               "#{parse_comments(statements, statement_index).join("\n")}\n"
             )
 

--- a/lib/syntax_tree/visitor.rb
+++ b/lib/syntax_tree/visitor.rb
@@ -23,8 +23,8 @@ module SyntaxTree
     # Visit an ArgStar node.
     alias visit_arg_star visit_child_nodes
 
-    # Visit an Args node.
-    alias visit_args visit_child_nodes
+    # Visit an ArgumentsNode node.
+    alias visit_arguments_node visit_child_nodes
 
     # Visit an ArgsForward node.
     alias visit_args_forward visit_child_nodes

--- a/tasks/sorbet.rake
+++ b/tasks/sorbet.rake
@@ -61,7 +61,7 @@ module SyntaxTree
 
       node_body << Command(
         Ident("attr_reader"),
-        Args([SymbolLiteral(Ident("location"))]),
+        ArgumentsNode([SymbolLiteral(Ident("location"))]),
         nil,
         location
       )
@@ -102,7 +102,7 @@ module SyntaxTree
 
         node_body << Command(
           Ident("attr_reader"),
-          Args([SymbolLiteral(Ident(attribute.name.to_s))]),
+          ArgumentsNode([SymbolLiteral(Ident(attribute.name.to_s))]),
           nil,
           location
         )
@@ -121,7 +121,7 @@ module SyntaxTree
           Period("."),
           Ident("returns"),
           ArgParen(
-            Args(
+            ArgumentsNode(
               [CallNode(VarRef(Const("T")), Period("."), Ident("untyped"), nil)]
             )
           )
@@ -214,7 +214,7 @@ module SyntaxTree
               VarRef(Const("T")),
               Period("."),
               Ident("unsafe"),
-              ArgParen(Args([VarRef(Kw("nil"))]))
+              ArgParen(ArgumentsNode([VarRef(Kw("nil"))]))
             )
           ]
         else
@@ -304,11 +304,11 @@ module SyntaxTree
     end
 
     def sig_params
-      CallNode(nil, nil, Ident("params"), ArgParen(Args([yield])))
+      CallNode(nil, nil, Ident("params"), ArgParen(ArgumentsNode([yield])))
     end
 
     def sig_returns
-      CallNode(nil, nil, Ident("returns"), ArgParen(Args([yield])))
+      CallNode(nil, nil, Ident("returns"), ArgParen(ArgumentsNode([yield])))
     end
 
     def sig_type_for(type)
@@ -319,7 +319,7 @@ module SyntaxTree
           sig_type_for(type.type)
         )
       when Reflection::Type::TupleType
-        ArrayLiteral(LBracket("["), Args(type.types.map { sig_type_for(_1) }))
+        ArrayLiteral(LBracket("["), ArgumentsNode(type.types.map { sig_type_for(_1) }))
       when Reflection::Type::UnionType
         if type.types.include?(NilClass)
           selected = type.types.reject { _1 == NilClass }
@@ -334,14 +334,14 @@ module SyntaxTree
             VarRef(Const("T")),
             Period("."),
             Ident("nilable"),
-            ArgParen(Args([sig_type_for(subtype)]))
+            ArgParen(ArgumentsNode([sig_type_for(subtype)]))
           )
         else
           CallNode(
             VarRef(Const("T")),
             Period("."),
             Ident("any"),
-            ArgParen(Args(type.types.map { sig_type_for(_1) }))
+            ArgParen(ArgumentsNode(type.types.map { sig_type_for(_1) }))
           )
         end
       when Symbol

--- a/test/node_test.rb
+++ b/test/node_test.rb
@@ -68,7 +68,9 @@ module SyntaxTree
       source = "method(first, second, third)"
 
       at = location(chars: 7..27)
-      assert_node(Args, source, at: at) { |node| node.arguments.arguments }
+      assert_node(ArgumentsNode, source, at: at) do |node|
+        node.arguments.arguments
+      end
     end
 
     def test_arg_block
@@ -76,7 +78,7 @@ module SyntaxTree
 
       at = location(chars: 17..23)
       assert_node(ArgBlock, source, at: at) do |node|
-        node.arguments.arguments.parts[1]
+        node.arguments.arguments.arguments[1]
       end
     end
 
@@ -90,7 +92,7 @@ module SyntaxTree
 
         at = location(lines: 2..2, chars: 29..30)
         assert_node(ArgBlock, source, at: at) do |node|
-          node.bodystmt.statements.body.first.arguments.arguments.parts[0]
+          node.bodystmt.statements.body.first.arguments.arguments.arguments[0]
         end
       end
     end
@@ -100,7 +102,7 @@ module SyntaxTree
 
       at = location(chars: 15..25)
       assert_node(ArgStar, source, at: at) do |node|
-        node.arguments.arguments.parts[1]
+        node.arguments.arguments.arguments[1]
       end
     end
 
@@ -114,7 +116,7 @@ module SyntaxTree
 
         at = location(lines: 2..2, chars: 29..32)
         assert_node(ArgsForward, source, at: at) do |node|
-          node.bodystmt.statements.body.first.arguments.arguments.parts.last
+          node.bodystmt.statements.body.first.arguments.arguments.arguments.last
         end
       end
     end
@@ -176,7 +178,7 @@ module SyntaxTree
 
       at = location(chars: 7..33)
       assert_node(BareAssocHash, source, at: at) do |node|
-        node.arguments.arguments.parts.first
+        node.arguments.arguments.arguments.first
       end
     end
 


### PR DESCRIPTION
I tried to address #351 since it seemd limited in scope, so hopefully:

- Fixes #351
- Changed all use of `parts` to `arguments` as well.


I was not sure if the `s(:args, children, location)` in `lib/syntax_tree/translation/parser.rb` should be updated as well (tried it but it broke the tests).
And the replacement of `parts` -> `arguments` was trial-and-error in a lot of places, since it was hard to know the types of
`node.contens.arguments.arguments.arguments` or something similar.

Please let me know if I should change anything, or feel free to reject the changes :) 
