### PR TITLE
Always use do/end for multiline lambdas

### DIFF
--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -7210,36 +7210,17 @@ module SyntaxTree
         q.text(" ")
         q
           .if_break do
-            force_parens =
-              q.parents.any? do |node|
-                node.is_a?(Command) || node.is_a?(CommandCall)
-              end
+            q.text("do")
 
-            if force_parens
-              q.text("{")
-
-              unless statements.empty?
-                q.indent do
-                  q.breakable_space
-                  q.format(statements)
-                end
+            unless statements.empty?
+              q.indent do
                 q.breakable_space
+                q.format(statements)
               end
-
-              q.text("}")
-            else
-              q.text("do")
-
-              unless statements.empty?
-                q.indent do
-                  q.breakable_space
-                  q.format(statements)
-                end
-              end
-
-              q.breakable_space
-              q.text("end")
             end
+
+            q.breakable_space
+            q.text("end")
           end
           .if_flat do
             q.text("{")

--- a/test/fixtures/lambda.rb
+++ b/test/fixtures/lambda.rb
@@ -80,3 +80,31 @@ end
 -> do # comment1
   # comment2
 end
+% # multiline lambda in a command
+command "arg" do
+  -> {
+    multi
+    line
+  }
+end
+-
+command "arg" do
+  -> do
+    multi
+    line
+  end
+end
+% # multiline lambda in a command call
+command.call "arg" do
+  -> {
+    multi
+    line
+  }
+end
+-
+command.call "arg" do
+  -> do
+    multi
+    line
+  end
+end


### PR DESCRIPTION
Fixes #379 

Previously lambda blocks inside a Command/CommandCall were always using braces, even when multiline.

This removes the special handling of multiline lambda blocks, that was forcing curly braces when any of the parents were a `Command` or `CommandCall`.

I don't understand why that was there so I can't tell if it's somehow important, but no tests failed and it made the two added fixtures pass.