### PR TITLE
Fix formatting for CHAR node when single_quotes plugin is enabled

### DIFF
--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -288,7 +288,7 @@ module SyntaxTree
         q.text(value)
       else
         q.text(q.quote)
-        q.text(value[1] == "\"" ? "\\\"" : value[1])
+        q.text(value[1] == q.quote ? "\\#{q.quote}" : value[1])
         q.text(q.quote)
       end
     end

--- a/test/plugin/single_quotes_test.rb
+++ b/test/plugin/single_quotes_test.rb
@@ -8,6 +8,14 @@ module SyntaxTree
       assert_format("''\n", "\"\"")
     end
 
+    def test_character_literal_with_double_quote
+      assert_format("'\"'\n", "?\"")
+    end
+
+    def test_character_literal_with_singlee_quote
+      assert_format("'\\''\n", "?'")
+    end
+
     def test_string_literal
       assert_format("'string'\n", "\"string\"")
     end


### PR DESCRIPTION
Fixes #384.

I've fixed formatting behavior for a CHAR node `?"` and `?'` when single_quotes plugin is enabled.
