### PR TITLE
Fix WithScope for destructured post arguments

### DIFF
--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -8277,8 +8277,8 @@ module SyntaxTree
     # parameter
     attr_reader :rest
 
-    # [Array[ Ident ]] any positional parameters that exist after a rest
-    # parameter
+    # [Array[ Ident | MLHSParen ]] any positional parameters that exist after a
+    #  rest parameter
     attr_reader :posts
 
     # [Array[ [ Label, nil | Node ] ]] any keyword parameters and their

--- a/lib/syntax_tree/with_scope.rb
+++ b/lib/syntax_tree/with_scope.rb
@@ -152,10 +152,7 @@ module SyntaxTree
     # arguments.
     def visit_params(node)
       add_argument_definitions(node.requireds)
-
-      node.posts.each do |param|
-        current_scope.add_local_definition(param, :argument)
-      end
+      add_argument_definitions(node.posts)
 
       node.keywords.each do |param|
         current_scope.add_local_definition(param.first, :argument)

--- a/test/with_scope_test.rb
+++ b/test/with_scope_test.rb
@@ -154,6 +154,42 @@ module SyntaxTree
       assert_argument(collector, "a", definitions: [1], usages: [2])
     end
 
+    def test_collecting_methods_with_destructured_post_arguments
+      collector = Collector.collect(<<~RUBY)
+        def foo(optional = 1, (bin, bag))
+        end
+      RUBY
+
+      assert_equal(3, collector.arguments.length)
+      assert_argument(collector, "optional", definitions: [1], usages: [])
+      assert_argument(collector, "bin", definitions: [1], usages: [])
+      assert_argument(collector, "bag", definitions: [1], usages: [])
+    end
+
+    def test_collecting_methods_with_desctructured_post_using_splat
+      collector = Collector.collect(<<~RUBY)
+        def foo(optional = 1, (bin, bag, *))
+        end
+      RUBY
+
+      assert_equal(3, collector.arguments.length)
+      assert_argument(collector, "optional", definitions: [1], usages: [])
+      assert_argument(collector, "bin", definitions: [1], usages: [])
+      assert_argument(collector, "bag", definitions: [1], usages: [])
+    end
+
+    def test_collecting_methods_with_nested_desctructured
+      collector = Collector.collect(<<~RUBY)
+        def foo(optional = 1, (bin, (bag)))
+        end
+      RUBY
+
+      assert_equal(3, collector.arguments.length)
+      assert_argument(collector, "optional", definitions: [1], usages: [])
+      assert_argument(collector, "bin", definitions: [1], usages: [])
+      assert_argument(collector, "bag", definitions: [1], usages: [])
+    end
+
     def test_collecting_singleton_method_arguments
       collector = Collector.collect(<<~RUBY)
         def self.foo(a)


### PR DESCRIPTION
This was caught by one of YARP's fixtures. When you have

```ruby
def foo(a = 1, (b, c))
end
```

Then `posts` will include a `MLHSParen`, which we need to account for in `WithScope` and also in the typing annotations.