### PR TITLE
Mention `write` from the `format` command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ SyntaxTree::Binary[
 
 ### format
 
-This command will output the formatted version of each of the listed files. Importantly, it will not write that content back to the source files. It is meant to display the formatted version only.
+This command will output the formatted version of each of the listed files to stdout. Importantly, it will not write that content back to the source files – for that, you want [`write`](#write).
 
 ```sh
 stree format path/to/file.rb


### PR DESCRIPTION
When trying to figure out how to format a new Ruby project, we were choosing between `@prettier/plugin-ruby`, this project, and Rufo. 

At first, we thought this project didn't have built-in support for writing to disk at all, so we almost switched to Rufo (or prettier-ruby, despite that library's admonition to use this gem). Only when I said, "no, Kevin wouldn't ship a library like this without a `--write` facility!" did we keep scrolling and find the `write` command.