### PR TITLE
Enable more tests now that TruffleRuby supports pattern matching

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -106,17 +106,15 @@ module SyntaxTree
       refute_includes(json, "#<")
       assert_equal(type, JSON.parse(json)["type"])
 
-      if RUBY_ENGINE != "truffleruby"
-        # Get a match expression from the node, then assert that it can in fact
-        # match the node.
-        # rubocop:disable all
-        assert(eval(<<~RUBY))
-          case node
-          in #{node.construct_keys}
-            true
-          end
-        RUBY
-      end
+      # Get a match expression from the node, then assert that it can in fact
+      # match the node.
+      # rubocop:disable all
+      assert(eval(<<~RUBY))
+        case node
+        in #{node.construct_keys}
+          true
+        end
+      RUBY
     end
 
     Minitest::Test.include(self)

--- a/test/translation/parser_test.rb
+++ b/test/translation/parser_test.rb
@@ -95,7 +95,7 @@ module SyntaxTree
         )
       end
 
-      if current_version < "3.2" || RUBY_ENGINE == "truffleruby"
+      if current_version < "3.2"
         known_failures.push(
           "test_if_while_after_class__since_32:11004",
           "test_if_while_after_class__since_32:11014",


### PR DESCRIPTION
I also looked at the remaining occurences of truffleruby in the repo.
The remaining ones are still needed (e.g. to skip slow & Ripper-transient tests).

I also found
https://github.com/ruby-syntax-tree/syntax_tree/blob/43ca866da9225cf3952d9a795224c09dff665150/lib/syntax_tree/language_server.rb#L171-L174
Which could use Ruby pattern matching again if desired.