### PR TITLE
Formatting proposal: Ensure empty line between method definitions

### DIFF
--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -9981,6 +9981,11 @@ module SyntaxTree
           q.breakable_force
           q.breakable_force
           q.format(statement)
+        elsif statement.is_a?(DefNode) && previous.is_a?(DefNode) &&
+              (statement.location.start_line - line) == 1
+          q.breakable_force
+          q.breakable_force
+          q.format(statement)
         elsif statement.location.start_line != line
           q.breakable_force
           q.format(statement)

--- a/test/fixtures/def.rb
+++ b/test/fixtures/def.rb
@@ -29,3 +29,14 @@ def
 =end
 a
 end
+%
+def foo
+end
+def bar
+end
+-
+def foo
+end
+
+def bar
+end

--- a/test/fixtures/defs.rb
+++ b/test/fixtures/defs.rb
@@ -29,3 +29,14 @@ end
 -
 def foo.foo
 end
+%
+def foo.foo
+end
+def foo.bar
+end
+-
+def foo.foo
+end
+
+def foo.bar
+end


### PR DESCRIPTION
We've been using SyntaxTree extensively for formatting in a number of our apps at work, and I recently came across something I was a bit surprised wasn't already part of the formatting rules: ensuring there's a blank line between each method definition.

**Before this change, the following code would be unchanged by SyntaxTree:**
```ruby
def foo
end
def bar
end
```

**After, it will be formatted like so:**
```ruby
def foo
end

def bar
end
```

I _think_ this is a fairly uncontroversial formatting opinion (though I've certainly misjudged these before 😄).  It lines up with the RuboCop default for [`Layout/EmptyLineBetweenDefs`](https://docs.rubocop.org/rubocop/1.63/cops_layout.html#layoutemptylinebetweendefs), which of course is disable when using the SyntaxTree RuboCop config.  I stopped short of doing the same for classes and modules as method definitions seemed the most common to have in succession.

I took a swing at implementing the change, but I'm not terribly confident that this is exactly the right approach.  I have run this against a few of our code bases and haven't seen any unintended changes.

Is this something you'd consider tweaking in SyntaxTree?  If so, is there anything I can do differently in the implementation to help it fit in with the rest of the project?