### PR TITLE
[WIP] Long call chain comment formatting

### DIFF
--- a/lib/syntax_tree/node.rb
+++ b/lib/syntax_tree/node.rb
@@ -2849,9 +2849,10 @@ module SyntaxTree
             # to print the operator trailing in order to keep it working.
             last_child = children.last
             if last_child.is_a?(CallNode) && last_child.message != :call &&
+                 last_child.operator &&
                  (
-                   (last_child.message.comments.any? && last_child.operator) ||
-                     (last_child.operator && last_child.operator.comments.any?)
+                   last_child.message.comments.any? ||
+                     last_child.operator.comments.any?
                  )
               q.format(CallOperatorFormatter.new(last_child.operator))
               skip_operator = true

--- a/test/fixtures/call.rb
+++ b/test/fixtures/call.rb
@@ -40,6 +40,15 @@ foo
   qux
   .quux
 %
+result =
+  fooooooooooooooooo
+    .barrrrrrrrrrrrrrrrrrr
+    .bazzzzzzzzzzzzzzzzzzz
+    # long comment long comment long comment long comment long comment
+    # long comment long comment long comment long comment long comment
+    # long comment long comment long comment long comment long comment
+    .quxxxxxxxxxxxxxxxxxxx
+%
 { a: 1, b: 2 }.fooooooooooooooooo.barrrrrrrrrrrrrrrrrrr.bazzzzzzzzzzzz.quxxxxxxxxxxxx
 -
 { a: 1, b: 2 }.fooooooooooooooooo


### PR DESCRIPTION
Investigating #411

Have traced it back to this change https://github.com/ruby-syntax-tree/syntax_tree/commit/b3457654ee196f752c7c936b426a99f6888b1608#diff-4a62a987e00853ea4da04a58594e31564bc9afc77a1cbdf95f95493784360659R2852-R2855