### PR TITLE
Disable rubocop Style/RegexpLiteral

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -62,3 +62,8 @@ Style/TrailingCommaInArrayLiteral:
 
 Style/TrailingCommaInHashLiteral:
   Enabled: false
+
+# Syntax Tree may rewrite regular expressions using different delimiters
+# than the ones enforced by RuboCop's Style/RegexpLiteral cop.
+Style/RegexpLiteral:
+  Enabled: false


### PR DESCRIPTION
We noticed a formatting difference for regex between rubocop and syntax_tree, which causes back-and-forth changes between the two tools.

For example, this is what the code looks like when formatted by `rubocop`:
```ruby
let(:gotcha_with_check_deleted_lines) do
  {
    text: 'Couchbase model gotcha',
    file_regexp: %r{^app/models/.*\.rb},
    keywords: [/ attribute :/],
    check_deleted_lines: true,
  }
 ```
 
And this is what it looks like when formatted by `syntax_tree`: 
 ```ruby
 let(:gotcha_with_check_deleted_lines) do
  {
    text: 'Couchbase model gotcha',
    file_regexp: %r{^app/models/.*\.rb},
    keywords: [%r{ attribute :}],
    check_deleted_lines: true,
  }
 ```
 
Therefore, I propose disabling `Style/RegexpLiteral` in `config/rubocop.yml` and letting `syntax_tree` handle regex formatting.